### PR TITLE
SITES-20: Upgrade path for stanford_ssp/stanford_simplesamlphp_auth from simplesamlphp_auth

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,24 +1,110 @@
 engines:
+  # https://docs.codeclimate.com/docs/eslint
+  # ES Linting requires an .eslintrc file to tweak checks.
   eslint:
-    enabled: true
+    enabled: false
   csslint:
     enabled: true
-  phpcodesniffer:
-    enabled: true
-    config:
-      file_extensions: "php,inc,install,module,profile"
-      standard: "Drupal"
-  phpmd:
-    enabled: true
-    config:
-      file_extensions:
-      - inc
-      - module
-      - profile
-      - php
-      - install
+    checks:
+      overqualified-elements:
+        enabled: false
+  # We don't lint our coffee. Eew.
+  coffeelint:
+    enabled: false
+  # SCSS Lint requires a .scss-lint.yml file in the repo in order to tweak settings.
+  # Withouth the .scss-lint.yml file it will run with the defaults.
+  # Defaults file: https://github.com/brigade/scss-lint/blob/master/config/default.yml
   scss-lint:
     enabled: true
+    checks:
+      IdSelector:
+        enabled: false
+      ColorVariable:
+        enabled: false
+      PropertySortOrder:
+        enabled: false
+      SelectorDepth:
+        enabled: false
+      QualifyingElement:
+        enabled: false
+      VendorPrefix:
+        enabled: false
+      LeadingZero:
+        enabled: false
+  phpcodesniffer:
+    enabled: true
+    checks:
+      Drupal Commenting FunctionComment TypeHintMissing:
+        enabled: false
+      Drupal Commenting FunctionComment IncorrectTypeHint:
+        enabled: false
+      DrupalPractice Commenting CommentEmptyLine SpacingAfter:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName ScopeNotCamelCaps:
+        enabled: false
+      Drupal NamingConventions ValidClassName StartWithCaptial:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName NotCamelCaps:
+        enabled: false
+      DrupalPractice General ClassName ClassPrefix:
+        enabled: false
+      Drupal NamingConventions ValidClassName NoUnderscores:
+        enabled: false
+    config:
+      file_extensions: "php,inc,install,module,profile"
+      standard: "Drupal,DrupalPractice"
+  phpmd:
+    enabled: true
+    checks:
+      Design/WeightedMethodCount:
+        enabled: false
+      CleanCode/StaticAccess:
+        enabled: false
+      CleanCode/ElseExpression:
+        enabled: false
+      CleanCode/BooleanArgumentFlag:
+        enabled: false
+      UnusedFormalParameter:
+        enabled: false
+    config:
+      # https://phpmd.org/rules/index.html
+      # The following sets include everything except the controversial set.
+      # We can configure these further through .xml files. See docs.
+      rulesets: "cleancode,codesize,design,naming,unusedcode"
+      # Include special Drupal file extensions.
+      file_extensions: "inc,module,profile,php,install"
+  # https://docs.codeclimate.com/docs/phan
+  phan:
+    enabled: true
+    config:
+      file_extensions: "php,module,profile,inc"
+      # minimum-severity: 1
+      ignore-undeclared: true
+      # quick: true
+      # backward-compatiility-checks: true
+      # dead-code-detection: true
+  # https://docs.codeclimate.com/docs/duplication
+  duplication:
+    enabled: true
+    # exclude_paths:
+    #   - examples/
+    config:
+      languages:
+        javascript:
+          mass_threshold: 50
+          # count_threshold: 3
+        php:
+          mass_threshold: 60
+  fixme:
+    enabled: true
+    config:
+      strings:
+      - FIXME
+      - BUG
+      - TODO
+      - todo
+      - dpm
+      - dsm
 ratings:
   paths:
   - "**.inc"
@@ -26,11 +112,10 @@ ratings:
   - "**.profile"
   - "**.php"
   - "**.install"
-  - "**.css"
   - "**.scss"
   - "**.sass"
   - "**.js"
-##exclude these files/paths
+# exclude these files/paths
 exclude_paths:
 - "**.features.**"
 - "**.views_default.inc"
@@ -41,3 +126,8 @@ exclude_paths:
 - "test/**/*"
 - "**/vendor/**/*"
 - "**.min.*"
+- "tests/"
+- "spec/"
+- "**/vendor/"
+- "**.api.php"
+- "*.twig"

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.api.php
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.api.php
@@ -39,10 +39,13 @@ function hook_stanford_simplesamlphp_auth_user_roles_alter(&$roles) {
  * a boolean indicating the success of the access check. Access will be denied
  * if any implementations return FALSE.
  *
- * @param $attributes
+ * @param array $attributes
+ *   An array of attributes.
+ *
  * @return bool
+ *   True or false.
  */
-function hook_stanford_simplesamlphp_auth_allow_login($attributes) {
+function hook_stanford_simplesamlphp_auth_allow_login(array $attributes) {
   if (in_array('student', $attributes)) {
     return FALSE;
   }
@@ -59,11 +62,12 @@ function hook_stanford_simplesamlphp_auth_allow_login($attributes) {
  * to appropriate error pages, there is no message implementation at hook
  * invocation.
  *
- * @param $attributes
- * @param $ext_user
- *  The user object for the current user
+ * @param array $attributes
+ *   An array of attributes.
+ * @param object $ext_user
+ *   The user object for the current user.
  */
-function hook_stanford_simplesamlphp_auth_pre_login($attributes, $ext_user) {
+function hook_stanford_simplesamlphp_auth_pre_login(array $attributes, $ext_user) {
   // Disallow students from logging in with a specific role.
   if ($ext_user['roles'] == '3' && (in_array('student', $attributes))) {
     drupal_goto('some-error-page-path');

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
@@ -37,7 +37,7 @@ function stanford_simplesamlphp_handle_user_login_register() {
   if (!$ext_user) {
     // Cannot do an access denied here as it creates a redirect loop.
     // @todo: Handle this moar better.
-    drupal_set_message("Sorry, but you do not have access to this page.", "error");
+    drupal_set_message(t("Sorry, but you do not have access to this page."), "error");
     drupal_not_found();
     exit();
   }
@@ -200,6 +200,7 @@ function stanford_simplesamlphp_auth_log_the_user_in($ext_user = NULL) {
   // or incorrectly does a redirect which would leave the old session in place.
   drupal_session_regenerate();
 
+  $edit = array();
   user_module_invoke('login', $edit, $user);
 
   // If for some reason the user account was not able to be created we should
@@ -319,16 +320,16 @@ function stanford_simplesamlphp_auth_get_saml_attributes() {
 /**
  * Return any attributes provided by the SAML IDP.
  *
- * @param array $attribute
+ * @param string $attribute
  *   (optional) The attribute whose value to return.  Can be skipped if all
  *   attribute values are requested.
  *
- * @return string
+ * @return mixed
  *   If an attribute was provided, the value of the attribute is returned.
  *   Otherwise, an array of all attribute values is returned, keyed by
  *   attribute.
  */
-function stanford_simplesamlphp_auth_get_attributes(array $attribute = NULL) {
+function stanford_simplesamlphp_auth_get_attributes($attribute = NULL) {
   $attributes = stanford_simplesamlphp_auth_get_saml_attributes();
   if (is_null($attribute)) {
     return $attributes;
@@ -429,7 +430,7 @@ function stanford_simplesamlphp_auth_get_host() {
     'HTTP_X_FORWARDED_HOST',
     'HTTP_HOST',
     'SERVER_NAME',
-    'SERVER_ADDR'
+    'SERVER_ADDR',
   );
   $sourceTransformations = array(
     "HTTP_X_FORWARDED_HOST" => function($value) {

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
@@ -5,7 +5,6 @@
  * Contains non-hook implementations.
  */
 
-
 /**
  * Handles the log in and authentication of a user with SAML attributes.
  */
@@ -48,8 +47,7 @@ function stanford_simplesamlphp_handle_user_login_register() {
 }
 
 /**
- * Trys to find a local user that matches the SAML attributes by the authmap
- * table.
+ * Find a local user that matches the SAML attributes by the authmap table.
  */
 function stanford_simplesamlphp_auth_find_external_user($authname) {
 
@@ -62,9 +60,10 @@ function stanford_simplesamlphp_auth_find_external_user($authname) {
 }
 
 /**
+ * Match SAML Attributes to local accounts.
+ *
  * Trys to find a local account that matches the SAML attributes by trying to
  * match up user properties to saml attributes.
- *
  */
 function stanford_simplesamlphp_auth_find_local_user($username) {
 
@@ -91,6 +90,8 @@ function stanford_simplesamlphp_auth_find_local_user($username) {
 }
 
 /**
+ * Boolean check for autoenable feature.
+ *
  * @return bool
  *   Returns TRUE is users can be auto registered.
  */
@@ -100,7 +101,9 @@ function stanford_simplesamlphp_auth_is_auto_provision_enabled() {
 
 /**
  * Asks all modules if current federated user is allowed to login.
- * Returns FALSE if at least one module returns FALSE
+ *
+ * @return bool
+ *   Returns FALSE if at least one module returns FALSE
  */
 function stanford_simplesamlphp_auth_allow_user_by_attribute() {
   $attributes = stanford_simplesamlphp_auth_get_saml_attributes();
@@ -126,8 +129,7 @@ function stanford_simplesamlphp_auth_user_register() {
   $username = stanford_simplesamlphp_auth_get_username();
   $email = stanford_simplesamlphp_auth_get_email();
 
-
-   // Validate the name.
+  // Validate the name.
   if (!stanford_simplesamlphp_auth_valid_username($username)) {
     $username = stanford_simplesamlphp_auth_get_valid_username($username);
   }
@@ -278,6 +280,7 @@ function stanford_simplesamlphp_auth_moderate_local_login() {
 
 /**
  * Returns the SAML information static variable.
+ *
  * @return array
  *   SAML information array. see autoload.
  */
@@ -287,6 +290,7 @@ function stanford_simplesamlphp_auth_get_saml_info() {
 
 /**
  * Returns the SAML instance object: SimpleSAML_Configuration::getInstance()
+ *
  * @return object
  *   SimpleSAML_Configuration::getInstance()
  */
@@ -300,6 +304,7 @@ function stanford_simplesamlphp_auth_get_saml_instance() {
 
 /**
  * Returns the SAML instance object: SimpleSAML_Configuration::getInstance()
+ *
  * @return object
  *   SimpleSAML_Auth_Simple->getAttributes()
  */
@@ -314,16 +319,16 @@ function stanford_simplesamlphp_auth_get_saml_attributes() {
 /**
  * Return any attributes provided by the SAML IDP.
  *
- * @param $attribute
+ * @param array $attribute
  *   (optional) The attribute whose value to return.  Can be skipped if all
  *   attribute values are requested.
  *
- * @return
+ * @return string
  *   If an attribute was provided, the value of the attribute is returned.
  *   Otherwise, an array of all attribute values is returned, keyed by
  *   attribute.
  */
-function stanford_simplesamlphp_auth_get_attributes($attribute = NULL) {
+function stanford_simplesamlphp_auth_get_attributes(array $attribute = NULL) {
   $attributes = stanford_simplesamlphp_auth_get_saml_attributes();
   if (is_null($attribute)) {
     return $attributes;
@@ -359,7 +364,9 @@ function stanford_simplesamlphp_auth_is_authenticated() {
 }
 
 /**
- * @param $type string
+ * Set a logged out cookie for user.
+ *
+ * @param string $type
  *   The key of the cookie message type.
  */
 function stanford_simplesamlphp_auth_set_logged_out_cookie($type = "") {
@@ -376,17 +383,17 @@ function stanford_simplesamlphp_auth_set_logged_out_cookie($type = "") {
   switch ($type) {
     case "local_disabled":
       $text = "We're sorry, but local Drupal account login has been disabled.";
-      $error_type  = "error";
+      $error_type = "error";
       break;
 
     case "not_authorized":
       $text = "We're sorry, but that account is not authorized for this website.";
-      $error_type  = "error";
+      $error_type = "error";
       break;
 
     default:
       $value = "";
-      $error_type  = "";
+      $error_type = "";
   }
 
   if (empty($text)) {
@@ -416,27 +423,38 @@ function stanford_simplesamlphp_auth_get_logged_out_cookie() {
  * Helper function stolen from symphony.
  *
  * Gets and returns the domain name (host)
- *
  */
 function stanford_simplesamlphp_auth_get_host() {
-  $possibleHostSources = array('HTTP_X_FORWARDED_HOST', 'HTTP_HOST', 'SERVER_NAME', 'SERVER_ADDR');
+  $possibleHostSources = array(
+    'HTTP_X_FORWARDED_HOST',
+    'HTTP_HOST',
+    'SERVER_NAME',
+    'SERVER_ADDR'
+  );
   $sourceTransformations = array(
     "HTTP_X_FORWARDED_HOST" => function($value) {
       $elements = explode(',', $value);
       return trim(end($elements));
     }
   );
+
   $host = '';
   foreach ($possibleHostSources as $source) {
-    if (!empty($host)) break;
-    if (empty($_SERVER[$source])) continue;
+    if (!empty($host)) {
+      break;
+    }
+
+    if (empty($_SERVER[$source])) {
+      continue;
+    }
+
     $host = $_SERVER[$source];
     if (array_key_exists($source, $sourceTransformations)) {
       $host = $sourceTransformations[$source]($host);
     }
   }
 
-  // Remove port number from host
+  // Remove port number from host.
   $host = preg_replace('/:\d+$/', '', $host);
 
   return trim($host);
@@ -445,10 +463,10 @@ function stanford_simplesamlphp_auth_get_host() {
 /**
  * Validates a name for a user.
  *
- * @param $name
- *   The string name
+ * @param string $name
+ *   The string name.
  *
- * return bool
+ * @return bool
  *   True if valid name and not already taken.
  */
 function stanford_simplesamlphp_auth_valid_username($name = "") {
@@ -478,25 +496,28 @@ function stanford_simplesamlphp_auth_valid_username($name = "") {
 /**
  * Generates a unique name for the user if it already exists by appending an integer.
  *
- * @param $name
+ * @param string $name
+ *   The name.
+ *
  * @return mixed
+ *   Could be anything.
  */
 function stanford_simplesamlphp_auth_get_valid_username($name) {
   $trys = 1;
   $name_clone = $name . $trys;
-  while(!stanford_simplesamlphp_auth_valid_username($name_clone)) {
+  while (!stanford_simplesamlphp_auth_valid_username($name_clone)) {
     $trys++;
     $name_clone = $name . $trys;
   }
+
   return $name_clone;
 }
-
 
 /**
  * Checks if authentication via SimpleSAMLphp should be activated.
  *
  * @param bool $show_inactive_msg
- *   Whether to display the "module not activated" message
+ *   Whether to display the "module not activated" message.
  *
  * @return bool
  *   TRUE if simplesamlphp_auth is enabled.
@@ -533,8 +554,6 @@ function stanford_simplesamlphp_auth_is_enabled($show_inactive_msg = FALSE) {
   }
   return FALSE;
 }
-
-
 
 /**
  * Gets the authname attribute from the SAML assertion.

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.pages.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.pages.inc
@@ -27,7 +27,7 @@ function stanford_simplesamlphp_auth_loginpage() {
 
   // If the Drupal user object is available prompt a message to log out first.
   if ($user->uid > 1) {
-    drupal_set_message("You are already logged in an cannot log in again. Please log out first to switch users.", "error");
+    drupal_set_message(t("You are already logged in an cannot log in again. Please log out first to switch users."), "error");
     drupal_goto("user/" . $user->uid);
   }
 

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -10,7 +10,7 @@
  * @param  [type] &$form_state [description]
  * @return [type]              [description]
  */
-function stanford_ssp_configuration_form($form = array(), &$form_state) {
+function stanford_ssp_configuration_form($form, &$form_state) {
 
   // Vertical Tab container.
   $form['togglers'] = array(
@@ -616,7 +616,7 @@ function stanford_ssp_add_sso_user_submit(&$form, &$form_state) {
 
   // Account was not created.
   if (!isset($account->uid)) {
-    drupal_set_message("User account creation went wrong. Please try again.", "error");
+    drupal_set_message(t("User account creation went wrong. Please try again."), "error");
     return;
   }
 
@@ -629,7 +629,7 @@ function stanford_ssp_add_sso_user_submit(&$form, &$form_state) {
   // Was the notify checkbox checked?
   if ($form_state["values"]["notify"] && $account) {
     _user_mail_notify('status_activated', $account);
-    drupal_set_message("Email sent to user", "status");
+    drupal_set_message(t("Email sent to user"), "status");
   }
 
   // Save the sunetid to the db.
@@ -716,7 +716,7 @@ function stanford_ssp_remove_waird($form, &$form_state) {
   }
   $imp = implode("|", $xp);
   variable_set("stanford_simplesamlphp_auth_rolepopulation", $imp);
-  drupal_set_message("Role mapping was removed");
+  drupal_set_message(t("Role mapping was removed"));
 }
 
 /**
@@ -724,5 +724,3 @@ function stanford_ssp_remove_waird($form, &$form_state) {
  * HELPER / UTIL
  * *****************************************************************
  */
-
-

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -169,3 +169,31 @@ function stanford_ssp_update_7202(&$sandbox) {
   }
 
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Add 4 new roles.
+ */
+function stanford_ssp_update_7203(&$sandbox) {
+  // Add default roles.
+  $roles = array(
+    'SSO User',
+    'Stanford Student',
+    'Stanford Staff',
+    'Stanford Faculty',
+  );
+
+  foreach ($roles as $role) {
+    $role_exists = (bool) db_query("SELECT COUNT(*) FROM {role} WHERE name = :name", array(':name' => $role))->fetchField();
+    if (!$role_exists) {
+      db_insert('role')
+        ->fields(array(
+          'name' => $role,
+        ))
+        ->execute();
+      drupal_set_message(st('Added Role @role', array('@role' => $role)));
+    }
+  }
+
+}

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Schema definitions. Install/update/uninstall hooks.
@@ -79,8 +80,6 @@ function stanford_ssp_uninstall() {
   variable_del('stanford_ssp_show_sso_login');
   variable_del('stanford_ssp_sso_link_text');
   variable_del('stanford_ssp_debug');
-
-
 }
 
 /**
@@ -123,8 +122,6 @@ function stanford_ssp_schema() {
 }
 
 /**
- * Implements hook_update_N().
- *
  * Install database table matching SUNetIDs and user IDs.
  */
 function stanford_ssp_update_7200() {
@@ -132,8 +129,6 @@ function stanford_ssp_update_7200() {
 }
 
 /**
- * Implements hook_update_N().
- *
  * Update any existing authmaps from left over systems.
  */
 function stanford_ssp_update_7201(&$sandbox) {
@@ -144,8 +139,6 @@ function stanford_ssp_update_7201(&$sandbox) {
 }
 
 /**
- * Implements hook_update_N().
- *
  * Enable two new dependencies: switch and stanford_simplesamlphp_auth.
  */
 function stanford_ssp_update_7202() {
@@ -228,8 +221,8 @@ function stanford_ssp_update_7204() {
   // If the variable from simplesamlphp_auth is set, set
   // stanford_simplesamlphp_auth_foo to that value.
   foreach ($contrib_variables as $var => $new_value) {
-    $old_value = variable_get($var);
-    if (isset($old_value)) {
+    $old_value = variable_get($var, NULL);
+    if (!is_null($old_value)) {
       variable_set('stanford_' . $var, $old_value);
     }
     else {
@@ -245,13 +238,15 @@ function stanford_ssp_update_7204() {
   else {
     variable_set('stanford_ssp_force_https', FALSE);
   }
+
   $roleevaleverytime = variable_get('simplesamlphp_auth_roleevaleverytime');
-  if ($roleevaleverytime = "1") {
+  if ($roleevaleverytime == "1") {
     variable_set('stanford_ssp_auth_role_map', 'reassign');
   }
   else {
     variable_set('simplesamlphp_auth_roleevaleverytime', 'grant');
   }
+
   // And then a bunch we want to set explicitly.
   variable_set('stanford_simplesamlphp_auth_unique_id', 'uid');
   variable_set('stanford_ssp_automagic_login', TRUE);
@@ -267,17 +262,14 @@ function stanford_ssp_update_7204() {
 }
 
 /**
- * Implements hook_update_N().
- *
- * Disable simplesamlphp_auth contrib module.
+ * Disable and uninstall simplesamlphp_auth contrib module.
  */
 function stanford_ssp_update_7205() {
-  module_disable(array('simplesamlphp_auth'));
+  module_disable(array('simplesamlphp_auth'), FALSE);
+  drupal_uninstall_modules(array('simplesamlphp_auth'), FALSE)
 }
 
 /**
- * Implements hook_update_N().
- *
  * Grant permission for administrator role to administer stanford_ssp.
  */
 function stanford_ssp_update_7206() {

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -79,6 +79,8 @@ function stanford_ssp_uninstall() {
   variable_del('stanford_ssp_show_sso_login');
   variable_del('stanford_ssp_sso_link_text');
   variable_del('stanford_ssp_debug');
+
+
 }
 
 /**
@@ -196,4 +198,65 @@ function stanford_ssp_update_7203(&$sandbox) {
     }
   }
 
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Set variables based on simplesamlphp_auth settings.
+ */
+function stanford_ssp_update_7204(&$sandbox) {
+  // Create an array where the key is the name of the simplesamlphp_auth variable, and the value is the stanford_simplesamlphp_auth default value.
+  $simplesamlphp_auth_variables = array(
+    'simplesamlphp_auth_activate' => TRUE,
+    'simplesamlphp_auth_allowdefaultlogin' => TRUE,
+    'simplesamlphp_auth_allowdefaultloginroles' => '',
+    'simplesamlphp_auth_allowdefaultloginusers' => '',
+    'simplesamlphp_auth_allowsetdrupalpwd' => FALSE,
+    'simplesamlphp_auth_authsource' => 'default-sp',
+    'simplesamlphp_auth_installdir' => '/opt/simplesamlphp',
+    'simplesamlphp_auth_logoutgotourl' => '',
+    'simplesamlphp_auth_mailattr' => 'mail',
+    'simplesamlphp_auth_registerusers' => TRUE,
+    'simplesamlphp_auth_rolepopulation' => '',
+    'simplesamlphp_auth_user_name' => 'displayName',
+    'simplesamlphp_auth_user_register_original' => '',
+  );
+  // If the simplesamlphp_auth variable is set, set stanford_simplesamlphp_auth_foo to that value.
+  foreach($simplesamlphp_auth_variables as $var => $new_value) {
+    $old_value = variable_get($var);
+    if (isset($old_value)) {
+      variable_set('stanford_' . $var,$old_value);
+    }
+    else {
+      variable_set('stanford_' . $var, $new_value);
+    }
+  }
+  // A few variables don't have matching syntax.
+  $simplesamlphp_auth_forcehttps = variable_get('simplesamlphp_auth_forcehttps');
+  if ($simplesamlphp_auth_forcehttps == "1") {
+    variable_set('stanford_ssp_force_https', TRUE);
+  }
+  else {
+    variable_set('stanford_ssp_force_https', FALSE);
+  }
+  $simplesamlphp_auth_roleevaleverytime = variable_get('simplesamlphp_auth_roleevaleverytime');
+  if ($simplesamlphp_auth_roleevaleverytime = "1") {
+    variable_set('stanford_ssp_auth_role_map', 'reassign');
+  }
+  else {
+    variable_set('simplesamlphp_auth_roleevaleverytime', 'grant');
+  }
+  // And then a bunch we want to set explicitly.
+  variable_set('stanford_simplesamlphp_auth_unique_id', 'uid');
+  variable_set('stanford_ssp_automagic_login', TRUE);
+  variable_set('stanford_ssp_redirect_on_login', FALSE);
+  variable_set('stanford_simplesamlphp_auth_autoenablesaml', TRUE);
+  variable_set('stanford_ssp_prevent_cache', FALSE);
+  variable_set('stanford_ssp_auth_restrictions', 'any');
+  variable_set('stanford_ssp_auth_restriction_sunet', '');
+  variable_set('stanford_ssp_auth_restriction_group', '');
+  variable_set('stanford_ssp_show_local_login', TRUE);
+  variable_set('stanford_ssp_show_sso_login', TRUE);
+  variable_set('stanford_ssp_sso_link_text', 'Log in with your SUNet ID »');
 }

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -122,12 +122,16 @@ function stanford_ssp_schema() {
 
 /**
  * Implements hook_update_N().
+ *
+ * Install database table matching SUNetIDs and user IDs.
  */
 function stanford_ssp_update_7200(&$sandbox) {
   drupal_install_schema("stanford_ssp");
 }
 
 /**
+ * Implements hook_update_N().
+ *
  * Update any existing authmaps from left over systems.
  */
 function stanford_ssp_update_7201(&$sandbox) {
@@ -138,7 +142,9 @@ function stanford_ssp_update_7201(&$sandbox) {
 }
 
 /**
- * Enable two new dependencies: switch and stanford_simplesamlphp_auth
+ * Implements hook_update_N().
+ *
+ * Enable two new dependencies: switch and stanford_simplesamlphp_auth.
  */
 function stanford_ssp_update_7202(&$sandbox) {
 

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -166,8 +166,6 @@ function stanford_ssp_update_7202() {
 }
 
 /**
- * Implements hook_update_N().
- *
  * Add 4 new roles.
  */
 function stanford_ssp_update_7203() {
@@ -194,8 +192,6 @@ function stanford_ssp_update_7203() {
 }
 
 /**
- * Implements hook_update_N().
- *
  * Set variables based on simplesamlphp_auth settings.
  */
 function stanford_ssp_update_7204() {

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -127,7 +127,7 @@ function stanford_ssp_schema() {
  *
  * Install database table matching SUNetIDs and user IDs.
  */
-function stanford_ssp_update_7200(&$sandbox) {
+function stanford_ssp_update_7200() {
   drupal_install_schema("stanford_ssp");
 }
 
@@ -148,7 +148,7 @@ function stanford_ssp_update_7201(&$sandbox) {
  *
  * Enable two new dependencies: switch and stanford_simplesamlphp_auth.
  */
-function stanford_ssp_update_7202(&$sandbox) {
+function stanford_ssp_update_7202() {
 
   if (!module_exists('stanford_simplesamlphp_auth')) {
     if (!module_enable(array('stanford_simplesamlphp_auth'))) {
@@ -177,7 +177,7 @@ function stanford_ssp_update_7202(&$sandbox) {
  *
  * Add 4 new roles.
  */
-function stanford_ssp_update_7203(&$sandbox) {
+function stanford_ssp_update_7203() {
   // Add default roles.
   $roles = array(
     'SSO User',
@@ -205,7 +205,7 @@ function stanford_ssp_update_7203(&$sandbox) {
  *
  * Set variables based on simplesamlphp_auth settings.
  */
-function stanford_ssp_update_7204(&$sandbox) {
+function stanford_ssp_update_7204() {
   // Create an array where the key is the name of the simplesamlphp_auth
   // variable, and the value is the stanford_simplesamlphp_auth default value.
   // This works because Canada (mostly) kept the syntax the same.
@@ -271,6 +271,6 @@ function stanford_ssp_update_7204(&$sandbox) {
  *
  * Disable simplesamlphp_auth contrib module.
  */
-function stanford_ssp_update_7205(&$sandbox) {
+function stanford_ssp_update_7205() {
   module_disable(array('simplesamlphp_auth'));
 }

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -240,7 +240,7 @@ function stanford_ssp_update_7204() {
     variable_set('stanford_ssp_auth_role_map', 'reassign');
   }
   else {
-    variable_set('simplesamlphp_auth_roleevaleverytime', 'grant');
+    variable_set('stanford_ssp_auth_role_map', 'grant');
   }
 
   // And then a bunch we want to set explicitly.

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -206,7 +206,8 @@ function stanford_ssp_update_7203(&$sandbox) {
  * Set variables based on simplesamlphp_auth settings.
  */
 function stanford_ssp_update_7204(&$sandbox) {
-  // Create an array where the key is the name of the simplesamlphp_auth variable, and the value is the stanford_simplesamlphp_auth default value.
+  // Create an array where the key is the name of the simplesamlphp_auth
+  // variable, and the value is the stanford_simplesamlphp_auth default value.
   // This works because Canada (mostly) kept the syntax the same.
   $simplesamlphp_auth_variables = array(
     'simplesamlphp_auth_activate' => TRUE,
@@ -224,11 +225,12 @@ function stanford_ssp_update_7204(&$sandbox) {
     'simplesamlphp_auth_user_register_original' => '',
   );
 
-  // If the simplesamlphp_auth variable is set, set stanford_simplesamlphp_auth_foo to that value.
-  foreach($simplesamlphp_auth_variables as $var => $new_value) {
+  // If the variable from simplesamlphp_auth is set, set
+  // stanford_simplesamlphp_auth_foo to that value.
+  foreach ($simplesamlphp_auth_variables as $var => $new_value) {
     $old_value = variable_get($var);
     if (isset($old_value)) {
-      variable_set('stanford_' . $var,$old_value);
+      variable_set('stanford_' . $var, $old_value);
     }
     else {
       variable_set('stanford_' . $var, $new_value);

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -274,3 +274,13 @@ function stanford_ssp_update_7204() {
 function stanford_ssp_update_7205() {
   module_disable(array('simplesamlphp_auth'));
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Grant permission for administrator role to administer stanford_ssp.
+ */
+function stanford_ssp_update_7206() {
+  $admin_rid = variable_get('user_admin_role');
+  user_role_grant_permissions($admin_rid, array("administer stanford_ssp"));
+}

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -209,7 +209,7 @@ function stanford_ssp_update_7204() {
   // Create an array where the key is the name of the simplesamlphp_auth
   // variable, and the value is the stanford_simplesamlphp_auth default value.
   // This works because Canada (mostly) kept the syntax the same.
-  $simplesamlphp_auth_variables = array(
+  $contrib_variables = array(
     'simplesamlphp_auth_activate' => TRUE,
     'simplesamlphp_auth_allowdefaultlogin' => TRUE,
     'simplesamlphp_auth_allowdefaultloginroles' => '',
@@ -227,7 +227,7 @@ function stanford_ssp_update_7204() {
 
   // If the variable from simplesamlphp_auth is set, set
   // stanford_simplesamlphp_auth_foo to that value.
-  foreach ($simplesamlphp_auth_variables as $var => $new_value) {
+  foreach ($contrib_variables as $var => $new_value) {
     $old_value = variable_get($var);
     if (isset($old_value)) {
       variable_set('stanford_' . $var, $old_value);
@@ -238,15 +238,15 @@ function stanford_ssp_update_7204() {
   }
 
   // A few variables don't have matching syntax.
-  $simplesamlphp_auth_forcehttps = variable_get('simplesamlphp_auth_forcehttps');
-  if ($simplesamlphp_auth_forcehttps == "1") {
+  $forcehttps = variable_get('simplesamlphp_auth_forcehttps');
+  if ($forcehttps == "1") {
     variable_set('stanford_ssp_force_https', TRUE);
   }
   else {
     variable_set('stanford_ssp_force_https', FALSE);
   }
-  $simplesamlphp_auth_roleevaleverytime = variable_get('simplesamlphp_auth_roleevaleverytime');
-  if ($simplesamlphp_auth_roleevaleverytime = "1") {
+  $roleevaleverytime = variable_get('simplesamlphp_auth_roleevaleverytime');
+  if ($roleevaleverytime = "1") {
     variable_set('stanford_ssp_auth_role_map', 'reassign');
   }
   else {

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -266,7 +266,7 @@ function stanford_ssp_update_7204() {
  */
 function stanford_ssp_update_7205() {
   module_disable(array('simplesamlphp_auth'), FALSE);
-  drupal_uninstall_modules(array('simplesamlphp_auth'), FALSE)
+  drupal_uninstall_modules(array('simplesamlphp_auth'), FALSE);
 }
 
 /**

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -263,3 +263,12 @@ function stanford_ssp_update_7204(&$sandbox) {
   variable_set('stanford_ssp_show_sso_login', TRUE);
   variable_set('stanford_ssp_sso_link_text', 'Log in with your SUNet ID »');
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Disable simplesamlphp_auth contrib module.
+ */
+function stanford_ssp_update_7205(&$sandbox) {
+  module_disable(array('simplesamlphp_auth'));
+}

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -207,6 +207,7 @@ function stanford_ssp_update_7203(&$sandbox) {
  */
 function stanford_ssp_update_7204(&$sandbox) {
   // Create an array where the key is the name of the simplesamlphp_auth variable, and the value is the stanford_simplesamlphp_auth default value.
+  // This works because Canada (mostly) kept the syntax the same.
   $simplesamlphp_auth_variables = array(
     'simplesamlphp_auth_activate' => TRUE,
     'simplesamlphp_auth_allowdefaultlogin' => TRUE,
@@ -222,6 +223,7 @@ function stanford_ssp_update_7204(&$sandbox) {
     'simplesamlphp_auth_user_name' => 'displayName',
     'simplesamlphp_auth_user_register_original' => '',
   );
+
   // If the simplesamlphp_auth variable is set, set stanford_simplesamlphp_auth_foo to that value.
   foreach($simplesamlphp_auth_variables as $var => $new_value) {
     $old_value = variable_get($var);
@@ -232,6 +234,7 @@ function stanford_ssp_update_7204(&$sandbox) {
       variable_set('stanford_' . $var, $new_value);
     }
   }
+
   // A few variables don't have matching syntax.
   $simplesamlphp_auth_forcehttps = variable_get('simplesamlphp_auth_forcehttps');
   if ($simplesamlphp_auth_forcehttps == "1") {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Upgrade from old 'n' busted to new hotness

# Needed By (Date)
- 9.8.17

# Criticality
- How critical is this PR on a 1-10 scale? 10
- As we move to SAML authentication, we want this.

# Steps to Test

1. Install a site with the 1.x branch
2. Check this branch out
3. Run `drush updb`
4. Verify that your settings from the contrib `simplesamlphp_auth` are carried over

# Affected Projects or Products
- Oh, probably eventually everything in D7

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-20

# Notes
1. This does not address an upgrade path from earlier 2.x versions of `stanford_ssp/stanford_simplesamlphp_auth`, and indeed would likely break them. Given that we only have two sites using that version, it may be simplest just to manually update the `schema_version` for those two sites
2. I expect there will be some discussion around this PR
3. I will do further testing of this on sites that are using the 1.x version, once I identify candidates that have strayed the most from the defaults