### PR TITLE
Block fixes

### DIFF
--- a/modules/stanford_saml_block/stanford_saml_block.module
+++ b/modules/stanford_saml_block/stanford_saml_block.module
@@ -45,6 +45,17 @@ function stanford_saml_block_block_configure($delta = '') {
 }
 
 /**
+ * Implements hook_block_save().
+ */
+
+function stanford_saml_block_block_save($delta = '', $edit = array()) {
+  switch ($delta) {
+    case 'stanford_saml_block_login_block':
+      variable_set('stanford_ssp_link_text', filter_xss($edit['stanford_ssp_link_text']));
+  }
+}
+
+/**
  * Implements hook_block_view().
  */
 

--- a/modules/stanford_saml_block/stanford_saml_block.module
+++ b/modules/stanford_saml_block/stanford_saml_block.module
@@ -17,7 +17,7 @@ function stanford_saml_block_block_info() {
     'visibility' => BLOCK_VISIBILITY_NOTLISTED,
     'pages'      => "user\nuser/*",
     'weight'     => 0,
-    'region'     => '',
+    'region'     => -1,
     'cache'      => DRUPAL_NO_CACHE,
   );
   return $blocks;

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
@@ -528,7 +528,7 @@ function stanford_simplesamlphp_auth_is_enabled($show_inactive_msg = FALSE) {
 
   $failure = NULL;
   $is_activated = variable_get('stanford_simplesamlphp_auth_activate');
-  $basedir = variable_get('stanford_simplesamlphp_auth_installdir', '/usr/share/simplesamlphp');
+  $basedir = variable_get('stanford_simplesamlphp_auth_installdir', '/opt/simplesamlphp');
 
   if ($is_activated) {
     // Make sure we know where SimpleSAMLphp is.

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.install
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.install
@@ -66,7 +66,7 @@ function stanford_simplesamlphp_auth_requirements($phase) {
       );
     }
 
-    $basedir = variable_get('stanford_simplesamlphp_auth_installdir', '/usr/share/simplesamlphp');
+    $basedir = variable_get('stanford_simplesamlphp_auth_installdir', '/opt/simplesamlphp');
     if (!file_exists($basedir . '/lib/_autoload.php')) {
       $requirements['stanford_simplesamlphp_auth'] = array(
         'severity'    => REQUIREMENT_ERROR,

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -44,7 +44,7 @@ function stanford_simplesamlphp_auth_autoload() {
   $saml = array();
 
   // Get the simplesamlphp session.
-  $basedir = variable_get('stanford_simplesamlphp_auth_installdir', '/usr/share/simplesamlphp');
+  $basedir = variable_get('stanford_simplesamlphp_auth_installdir', '/opt/simplesamlphp');
 
   // Find out if simplesaml is available and can be loaded.
   if (file_exists($basedir . '/lib/_autoload.php')) {

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -83,6 +83,14 @@ function stanford_ssp_configuration_form($form, &$form_state) {
     '#description' => t("Enforce that authentication and authenticated transactions happen over HTTPS. This should be enabled on production websites."),
   );
 
+  // Reformat entitlements, replacing : with _
+  $form['general-config']['stanford_ssp_format_entitlements'] = array(
+    '#type' => 'switch',
+    '#title' => t('Reformat entitlements.'),
+    '#default_value' => variable_get('stanford_ssp_format_entitlements', FALSE),
+    '#description' => t("If your SP configuration reformats entitlements (e.g. stanford:stanford to stanford_stanford), enable this option."),
+  );
+
   $form['general-config'] ['stanford_ssp_redirect_on_login'] = array(
     '#type' => 'textfield',
     '#title' => t('Redirect all users on successful login to this url.'),

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -143,8 +143,8 @@ function stanford_ssp_configuration_form($form, &$form_state) {
   $form['saml-config']['stanford_simplesamlphp_auth_installdir'] = array(
     '#type' => 'textfield',
     '#title' => t('Installation directory'),
-    '#default_value' => variable_get('stanford_simplesamlphp_auth_installdir', '/usr/share/simplesamlphp'),
-    '#description' => t('The base directory of simpleSAMLphp. Absolute path with no trailing slash. default: /usr/share/simplesamlphp'),
+    '#default_value' => variable_get('stanford_simplesamlphp_auth_installdir', '/opt/simplesamlphp'),
+    '#description' => t('The base directory of simpleSAMLphp. Absolute path with no trailing slash. default: /opt/simplesamlphp'),
   );
 
   $form['saml-config']['stanford_simplesamlphp_auth_authsource'] = array(

--- a/stanford_ssp.drush.inc
+++ b/stanford_ssp.drush.inc
@@ -39,11 +39,6 @@ function stanford_ssp_drush_command() {
 
   $items['stanford-ssp-migrate-wmd'] = array(
     'description' => 'Migrate settings from the WebAuth Module for Drupal (WMD) to Stanford SimpleSAML PHP',
-    'options' => array(
-      'dry-run' => array(
-        'description'   => "Do a dry run and see what values will be changed.",
-      ),
-    ),
     'aliases' => array('sspwmd'),
   );
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -709,6 +709,12 @@ function stanford_ssp_import_webauth_settings() {
   }
 
   $sso_role = user_role_load_by_name('SSO User');
+  $sunet_role = user_role_load_by_name('SUNet User');
+  if ($sunet_role) {
+    drush_log("Transferring SUNet User permissions to SSO User.", "success");
+    $sunet_role_permissions = user_role_permissions(array($sunet_role->rid => $sunet_role->name));
+    user_role_grant_permissions($sso_role->rid, array_keys($sunet_role_permissions[$sunet_role->rid]));
+  }
 
   drush_log("Beginning webauth config settings to ssp settings conversion.", "success");
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -684,8 +684,11 @@ function stanford_ssp_form_user_pass_alter_validate($form, $form_state) {
  *   eg: anchorage_humanbiology-admins
  */
 function stanford_ssp_format_entitlement($entitlement) {
-  $entitlement = strtolower($entitlement);
-  $entitlement = str_replace(":", "_", $entitlement);
+  $format_enabled = variable_get('stanford_ssp_format_entitlements', FALSE);
+  if ($format_enabled) {
+    $entitlement = strtolower($entitlement);
+    $entitlement = str_replace(":", "_", $entitlement);
+  }
   return $entitlement;
 }
 
@@ -754,9 +757,10 @@ function stanford_ssp_import_webauth_settings() {
   // webauth_require_privgroups.
   $webauth_require_privgroups = variable_get("webauth_require_privgroups", FALSE);
   if ($webauth_require_privgroups) {
-    $webauth_require_privgroups = preg_replace('/\r\n/', ',', $webauth_require_privgroups);
-    $webauth_require_privgroups = preg_replace('/:/', '_', $webauth_require_privgroups);
-    variable_set("stanford_ssp_auth_restriction_groups", $webauth_require_privgroups);
+    $privgroups = explode("\r\n", $webauth_require_privgroups);
+    $privgroups = array_map('stanford_ssp_format_entitlement', $privgroups);
+    $webauth_require_privgroups = implode(',', $privgroups);
+    variable_set("stanford_ssp_auth_restriction_group", $webauth_require_privgroups);
   }
 
   // Update the authmap table to point existing users to ssp.
@@ -842,7 +846,7 @@ function stanford_ssp_convert_webauth_role_mappings() {
   foreach ($webauth_roles as $mapping) {
     // stanford_simplesamlphp_auth_rolepopulation = $rid:eduPersonEntitlement,=,$workgroup|$rid:eduPersonEntitlement,=,$workgroup
     // Replace colons with underscores.
-    $workgroup = preg_replace('/:/', '_', $mapping->wa_group);
+    $workgroup = stanford_ssp_format_entitlement($mapping->wa_group);
     $roles[] = $mapping->rid . ":eduPersonEntitlement,=," . $workgroup;
   }
   $new_rolepop = implode('|', $roles);


### PR DESCRIPTION
A few things are changed:

* the custom block wouldn't appear on the configuration page, so I couldn't update the link text nor the title. Changed the default region from 0 to -1 to make it appear.
* the custom block didn't have a save function for the link text
* I added a switch, disabled by default for the reformatting of entitlements. I wasn't sure if there was a need for configuration of what characters to replace with what others, so I left it simple for now.
* Using drush sspwmd, the permissions from SUNet User are copied over to SSO User
* There was a dry-run option that wasn't working, not implemented
* Updated the default install directory as discussed