### PR TITLE
SITES-616: Add workgroup API role mapping option

### DIFF
--- a/modules/stanford_saml_block/stanford_saml_block.module
+++ b/modules/stanford_saml_block/stanford_saml_block.module
@@ -9,7 +9,6 @@ include_once 'stanford_saml_block.features.inc';
 /**
  * Implements hook_block_info().
  */
-
 function stanford_saml_block_block_info() {
   $blocks['stanford_saml_block_login_block'] = array(
     'info'       => t('Stanford SimpleSAML PHP Authentication'),
@@ -23,23 +22,21 @@ function stanford_saml_block_block_info() {
   return $blocks;
 }
 
-
 /**
  * Implements hook_block_configure().
  */
-
 function stanford_saml_block_block_configure($delta = '') {
   $form = array();
   switch ($delta) {
     case 'stanford_saml_block_login_block':
       $form['stanford_ssp_link_text'] = array(
-      '#type'          => 'textfield',
-      '#title'         => t('Text of the SimpleSAML PHP login link'),
-      '#require'       => TRUE,
-      '#size'          => 60,
-      '#description'   => t('Here you can replace the text of the SimpleSAML PHP link.'),
-      '#default_value' => variable_get('stanford_ssp_link_text', 'SUNetID Login'),
-    );
+        '#type'          => 'textfield',
+        '#title'         => t('Text of the SimpleSAML PHP login link'),
+        '#require'       => TRUE,
+        '#size'          => 60,
+        '#description'   => t('Here you can replace the text of the SimpleSAML PHP link.'),
+        '#default_value' => variable_get('stanford_ssp_link_text', 'SUNetID Login'),
+      );
   }
   return $form;
 }
@@ -47,7 +44,6 @@ function stanford_saml_block_block_configure($delta = '') {
 /**
  * Implements hook_block_save().
  */
-
 function stanford_saml_block_block_save($delta = '', $edit = array()) {
   switch ($delta) {
     case 'stanford_saml_block_login_block':
@@ -58,7 +54,6 @@ function stanford_saml_block_block_save($delta = '', $edit = array()) {
 /**
  * Implements hook_block_view().
  */
-
 function stanford_saml_block_block_view($delta = '') {
   $block = array();
   switch ($delta) {

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
@@ -76,7 +76,8 @@ function stanford_simplesamlphp_auth_find_local_user($username) {
     $ext_user = user_load_by_mail($mail);
   }
 
-  // Give opportunity to load user according to load a different user according to fields received in the auth.
+  // Give opportunity to load user according to load a different user according
+  // to fields received in the auth.
   $auth_field = variable_get('simplesamlphp_auth_unique_id', 'eduPersonPrincipalName');
   $attributes = stanford_simplesamlphp_auth_get_saml_attributes();
   drupal_alter("saml_ext_user", $ext_user, $attributes, $auth_field);
@@ -407,7 +408,10 @@ function stanford_simplesamlphp_auth_set_logged_out_cookie($type = "") {
 }
 
 /**
- * Gets and processes the cookie in order to set a message for the logged out user.
+ * Get logged out cookie.
+ *
+ * Gets and processes the cookie in order to set a message for the logged
+ * out user.
  */
 function stanford_simplesamlphp_auth_get_logged_out_cookie() {
   if (isset($_COOKIE['stanford_simplesamlphp_auth_message'])) {
@@ -433,7 +437,7 @@ function stanford_simplesamlphp_auth_get_host() {
     'SERVER_ADDR',
   );
   $sourceTransformations = array(
-    "HTTP_X_FORWARDED_HOST" => function($value) {
+    "HTTP_X_FORWARDED_HOST" => function ($value) {
       $elements = explode(',', $value);
       return trim(end($elements));
     }
@@ -495,7 +499,10 @@ function stanford_simplesamlphp_auth_valid_username($name = "") {
 }
 
 /**
- * Generates a unique name for the user if it already exists by appending an integer.
+ * Generates a unique name.
+ *
+ *  Generates a unique name for the user if it already exists by appending an
+ *  integer.
  *
  * @param string $name
  *   The name.

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
@@ -539,7 +539,7 @@ function stanford_simplesamlphp_auth_is_enabled($show_inactive_msg = FALSE) {
 
   if ($is_activated) {
     // Make sure we know where SimpleSAMLphp is.
-    if (!file_exists($basedir)) {
+    if (!is_dir($basedir)) {
       $failure = t('SimpleSAMLphp could not be found at %basedir . The simplesamlphp_auth module cannot function until the path to the local SimpleSAMLphp instance is configured.', array('%basedir' => $basedir));
       watchdog('stanford_simplesamlphp_auth', $failure, NULL, WATCHDOG_WARNING);
     }

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.install
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.install
@@ -76,7 +76,7 @@ function stanford_simplesamlphp_auth_requirements($phase) {
       );
     }
     // SimpleSAMLphp is installed, lets autoload it.
-    else if (stanford_simplesamlphp_auth_autoload()) {
+    elseif (stanford_simplesamlphp_auth_autoload()) {
       // If autoloading was successful we should have these variables.
       global $stanford_simplesamlphp_auth_saml_config;
       global $stanford_simplesamlphp_auth_saml_version;

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -411,7 +411,7 @@ function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluat
 /**
  * Evaluate whether a user is in a workgroup through a SAML attribute.
  *
- * This evaluation is used when eduPersonEntitlement has not been released with
+ * This evaluation is used when eduPersonEntitlement property is released with
  * all of the private and normal workgroups that need to be available.
  *
  * @param array $roleruleevaluation

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -385,7 +385,7 @@ function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluat
 
   // Grab the sunet out of the SAML repsonse attributes and a few keys from the
   // SAML mapping rule.
-  $sunet = $attributes[variable_get('stanford_simplesamlphp_auth_unique_id', 'eduPersonPrincipalName')];
+  $sunet = array_pop($attributes[variable_get('stanford_simplesamlphp_auth_unique_id', 'eduPersonPrincipalName')]);
   $workgroup = $roleruleevaluation[2];
   $operation = $roleruleevaluation[1];
 

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -336,7 +336,7 @@ function stanford_simplesamlphp_auth_generate_block_text() {
  * @param array $attributes
  *   An array containing the SAML response identity attributes.
  *
- * @return array
+ * @return mixed
  *   An array containing role value and the attribute, or FALSE.
  */
 function stanford_simplesamlphp_auth_evaulaterolerule(array $roleruleevaluation, array $attributes) {
@@ -447,7 +447,7 @@ function stanford_simplesamlphp_auth_saml_evaluaterolerule(array $roleruleevalua
   // multiple values, returning true if any of the values match.
   switch ($roleruleevaluation[1]) {
     case '=':
-      return in_array($roleruleevaluation[2], $attribute);
+      return in_array($role_to_lookup, $attribute);
 
     case '@=':
       $dc = explode('@', $attribute[0]);
@@ -455,11 +455,11 @@ function stanford_simplesamlphp_auth_saml_evaluaterolerule(array $roleruleevalua
         return FALSE;
       }
 
-      return $dc[1] == $roleruleevaluation[2];
+      return $dc[1] == $role_to_lookup;
 
     case '~=':
       foreach ($attribute as $subattr) {
-        $pos = strpos($subattr, $roleruleevaluation[2]);
+        $pos = strpos($subattr, $role_to_lookup);
         if ($pos !== FALSE) {
           return TRUE;
         }

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -389,6 +389,11 @@ function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluat
   $workgroup = $roleruleevaluation[2];
   $operation = $roleruleevaluation[1];
 
+  // If formatting is on we need to change it back for the API.
+  if (variable_get("stanford_ssp_format_entitlements", TRUE)) {
+    $workgroup = str_replace("_", ":", $workgroup);
+  }
+
   // Unless you were crafty and drush set a special evaluation rule in to the
   // list of rules all operations should be exact matches as the UI doesn't give
   // any options for anything else. This is going to allow me to assume exact

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -351,11 +351,11 @@ function stanford_simplesamlphp_auth_evaulaterolerule(array $roleruleevaluation,
   }
 
   // What kind of eval are we going to perform?
-  $workgroup_source = varaiable_get('stanford_ssp_role_map_source', 'entitlement');
+  $workgroup_source = variable_get('stanford_ssp_role_map_source', 'entitlement');
 
   // If SAML eval check if the key exists in the attributes to start with.
   if ($workgroup_source == 'entitlement') {
-    return stanford_simplesamlphp_auth_saml_evaluaterolerule();
+    return stanford_simplesamlphp_auth_saml_evaluaterolerule($roleruleevaluation, $attributes);
   }
 
   // If workgroup API check the remote api for if this user is in one.
@@ -473,13 +473,13 @@ function stanford_simplesamlphp_auth_saml_evaluaterolerule(array $roleruleevalua
 /**
  * Performs role population.
  *
- * @param array $rolemap
+ * @param string $rolemap
  *   A string containing the role map.
  *
  * @return array
  *   An array containing user's roles.
  */
-function stanford_simplesamlphp_auth_rolepopulation(array $rolemap) {
+function stanford_simplesamlphp_auth_rolepopulation($rolemap) {
   $saml = stanford_simplesamlphp_auth_get_saml_info();
   $source = $saml['source'];
   $attributes = $saml["attributes"];

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -124,7 +124,7 @@ function stanford_simplesamlphp_auth_user_login(&$edit, $account) {
 }
 
 /**
- * Checks wether the user is allowed to be logged in or not.
+ * Checks whether the user is allowed to be logged in or not.
  *
  * @param object $user
  *   A loaded user object.
@@ -328,7 +328,7 @@ function stanford_simplesamlphp_auth_generate_block_text() {
 /**
  * Evaluates a role rule.
  *
- * Evaluate wether or not somebody who has logged in should get a role in
+ * Evaluate whether or not somebody who has logged in should get a role in
  * the Drupal website by evaluating the rules as set by the role mapping ui.
  *
  * @param array $roleruleevaluation
@@ -368,7 +368,7 @@ function stanford_simplesamlphp_auth_evaulaterolerule(array $roleruleevaluation,
 }
 
 /**
- * Evaluate wether a user is in a workgroup through the workgroup api.
+ * Evaluate whether a user is in a workgroup through the workgroup api.
  *
  * This evaluation is used when eduPersonEntitlement has not been released with
  * all of the private and normal workgroups that need to be available.
@@ -409,7 +409,7 @@ function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluat
 }
 
 /**
- * Evaluate wether a user is in a workgroup through a SAML attribute.
+ * Evaluate whether a user is in a workgroup through a SAML attribute.
  *
  * This evaluation is used when eduPersonEntitlement has not been released with
  * all of the private and normal workgroups that need to be available.

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -2,11 +2,11 @@
 
 /**
  * @file
- * simpleSAMLphp authentication module for Drupal.
+ * SimpleSAMLphp authentication module for Drupal.
  *
  * This authentication module is based on the shibboleth authentication module,
  * with changes to adapt to use simpleSAMLphp.
- **/
+ */
 
 /**
  * Implements hook_help().
@@ -99,17 +99,8 @@ function stanford_simplesamlphp_auth_init() {
 
 /**
  * Implements hook_user_login().
- *
- * @param $edit
- * @param $account
  */
 function stanford_simplesamlphp_auth_user_login(&$edit, $account) {
-
-  // Only execute this on auth mapped users.
-  // $saml = stanford_simplesamlphp_auth_get_saml_info();
-  // if (empty($saml['instance'])) {
-  //   return;
-  // }
 
   // Allow other modules to alter the users' roles.
   drupal_alter('stanford_simplesamlphp_auth_user_roles', $account);
@@ -134,8 +125,12 @@ function stanford_simplesamlphp_auth_user_login(&$edit, $account) {
 
 /**
  * Checks wether the user is allowed to be logged in or not.
- * @param  [type] $user [description]
- * @return [type]          [description]
+ *
+ * @param object $user
+ *   A loaded user object.
+ *
+ * @return bool
+ *   True if the user object passed in is allowed to authenticate.
  */
 function stanford_simplesamlphp_auth_validate_user_ability_to_login($user) {
 
@@ -146,7 +141,7 @@ function stanford_simplesamlphp_auth_validate_user_ability_to_login($user) {
   $saml = stanford_simplesamlphp_auth_get_saml_info();
   $is_saml = (isset($saml['instance']) && !empty($saml['instance']));
 
-  // Check if local user is allowed default login and not a saml user
+  // Check if local user is allowed default login and not a saml user.
   if (variable_get('stanford_simplesamlphp_auth_allowdefaultlogin', TRUE) && !$is_saml) {
 
     // Get users that are allowed default login.
@@ -249,15 +244,6 @@ function stanford_simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
     $form['links']['#markup'] = $link;
   }
 
-  // if (($form_id == 'user_register_form' || $is_user_profile_account_form) && user_access('change saml authentication setting')) {
-  //   $form['saml'] = array(
-  //     '#type' => 'checkbox',
-  //     '#title' => t('Enable this user to leverage SAML authentication'),
-  //     '#default_value' => $form_id == 'user_register_form' ? TRUE : (bool) user_get_authmaps($form['#user']->name),
-  //   );
-  //   $form['#submit'][] = 'simplesaml_auth_user_profile_form_submit';
-  // }
-
   // If the user has a simplesamlphp_auth authmap record, then don't require
   // them to know their Drupal password. This will allow them to change their
   // e-mail address, and set a Drupal password if they want to (and are
@@ -326,7 +312,7 @@ function stanford_simplesamlphp_auth_generate_block_text() {
   }
 
   // Check if valid local session exists..
-  if ($source ->isAuthenticated()) {
+  if ($source->isAuthenticated()) {
     $block_content .= '<p>' . t('Logged in as: @username', array('@username' => $user->name))
     . '<br />' . l(t('Log Out'), 'user/logout') . '</p>';
   }
@@ -342,23 +328,20 @@ function stanford_simplesamlphp_auth_generate_block_text() {
 /**
  * Evaluates a role rule.
  *
- * The rules work as follows:
- * = does an exact match on an attribute and will iterate over array values if
- * the array is multivalued.
- * @= matches the domain portion of an email address. It assumes the attribute
- * is a string, and will not iterate over an array (but take the first value).
- * ~= does a partial string match on the attribute, and does iterate over
- * multiple values, returning true if any of the values match.
+ * Evaluate wether or not somebody who has logged in should get a role in
+ * the Drupal website by evaluating the rules as set by the role mapping ui.
  *
  * @param array $roleruleevaluation
  *   An array containing the role rule to evaluate.
  * @param array $attributes
- *   An array containing the identity attributes.
+ *   An array containing the SAML response identity attributes.
  *
  * @return array
  *   An array containing role value and the attribute, or FALSE.
  */
-function stanford_simplesamlphp_auth_evaulaterolerule($roleruleevaluation, $attributes) {
+function stanford_simplesamlphp_auth_evaulaterolerule(array $roleruleevaluation, array $attributes) {
+
+  // For debugging.
   if (variable_get('stanford_simplesamlphp_auth_debug', 0)) {
     watchdog('stanford_simplesamlphp_auth', 'Evaluate rule (key=%key,operator=%op,value=%val)', array(
       '%key' => $roleruleevaluation[0],
@@ -367,11 +350,96 @@ function stanford_simplesamlphp_auth_evaulaterolerule($roleruleevaluation, $attr
     ), WATCHDOG_DEBUG);
   }
 
-  if (!array_key_exists($roleruleevaluation[0], $attributes)) {
+  // What kind of eval are we going to perform?
+  $workgroup_source = varaiable_get('stanford_ssp_role_map_source', 'entitlement');
+
+  // If SAML eval check if the key exists in the attributes to start with.
+  if ($workgroup_source == 'entitlement') {
+    return stanford_simplesamlphp_auth_saml_evaluaterolerule();
+  }
+
+  // If workgroup API check the remote api for if this user is in one.
+  if ($workgroup_source == "workgroup") {
+    return stanford_simplesamlphp_auth_api_evaluaterolerule($roleruleevaluation, $attributes);
+  }
+
+  // If for some reason we don't have a valid map source just return false.
+  return FALSE;
+}
+
+/**
+ * Evaluate wether a user is in a workgroup through the workgroup api.
+ *
+ * This evaluation is used when eduPersonEntitlement has not been released with
+ * all of the private and normal workgroups that need to be available.
+ *
+ * @param array $roleruleevaluation
+ *   The SAML evaluation rule. We re-use the group and operation keys.
+ * @param array $attributes
+ *   The SAML attributes given back from the SP.
+ *
+ * @return bool
+ *   True if the user is part of the workgroup.
+ */
+function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluation, array $attributes) {
+
+  // Grab the sunet out of the SAML repsonse attributes and a few keys from the
+  // SAML mapping rule.
+  $sunet = $attributes[variable_get('stanford_simplesamlphp_auth_unique_id', 'eduPersonPrincipalName')];
+  $workgroup = $roleruleevaluation[2];
+  $operation = $roleruleevaluation[1];
+
+  // Unless you were crafty and drush set a special evaluation rule in to the
+  // list of rules all operations should be exact matches as the UI doesn't give
+  // any options for anything else. This is going to allow me to assume exact
+  // matching for this evaluation.
+  if ($operation == "=") {
+    $members = stanford_ssp_get_workgroup_members_by_api($workgroup);
+    if (in_array($sunet, $members)) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+ * Evaluate wether a user is in a workgroup through a SAML attribute.
+ *
+ * This evaluation is used when eduPersonEntitlement has not been released with
+ * all of the private and normal workgroups that need to be available.
+ *
+ * @param array $roleruleevaluation
+ *   The SAML evaluation rule.
+ * @param array $attributes
+ *   The SAML attributes given back from the SP.
+ *
+ * @return bool
+ *   True if the user is part of the workgroup.
+ */
+function stanford_simplesamlphp_auth_saml_evaluaterolerule(array $roleruleevaluation, array $attributes) {
+
+  // The SAML attribute key to use.
+  $attribute_key = $roleruleevaluation[0];
+
+  // Which role from the rules are we evaluating.
+  $role_to_lookup = $roleruleevaluation[2];
+
+  if (!array_key_exists($attribute_key, $attributes)) {
     return FALSE;
   }
+
+  // Which SAML attribute to use as an eval key. Normally this is
+  // eduPersonEntitlement but there is nothing but the UI to enforce this.
   $attribute = $attributes[$roleruleevaluation[0]];
 
+  // The rules work as follows:
+  // = does an exact match on an attribute and will iterate over array values if
+  // the array is multivalued.
+  // @= matches the domain portion of an email address. It assumes the attribute
+  // is a string, and will not iterate over an array (but take the first value).
+  // ~= does a partial string match on the attribute, and does iterate over
+  // multiple values, returning true if any of the values match.
   switch ($roleruleevaluation[1]) {
     case '=':
       return in_array($roleruleevaluation[2], $attribute);
@@ -406,35 +474,36 @@ function stanford_simplesamlphp_auth_evaulaterolerule($roleruleevaluation, $attr
  * @return array
  *   An array containing user's roles.
  */
-function stanford_simplesamlphp_auth_rolepopulation($rolemap) {
+function stanford_simplesamlphp_auth_rolepopulation(array $rolemap) {
   $saml = stanford_simplesamlphp_auth_get_saml_info();
   $source = $saml['source'];
   $attributes = $saml["attributes"];
   $roles = array();
 
   // Check if valid local session exists..
-  if (!empty($rolemap) && $source->isAuthenticated()) {
-    $rolerules = explode('|', $rolemap);
+  if (empty($rolemap) || !$source->isAuthenticated()) {
+    return $roles;
+  }
 
-    foreach ($rolerules as $rolerule) {
+  $rolerules = explode('|', $rolemap);
+  foreach ($rolerules as $rolerule) {
 
-      $roleruledecompose = explode(':', $rolerule, 2);
-      $roleid = $roleruledecompose[0];
-      $roleruleevaluations = explode(';', $roleruledecompose[1]);
-      $addnew = TRUE;
+    $roleruledecompose = explode(':', $rolerule, 2);
+    $roleid = $roleruledecompose[0];
+    $roleruleevaluations = explode(';', $roleruledecompose[1]);
+    $addnew = TRUE;
 
-      foreach ($roleruleevaluations as $roleruleevaluation) {
-        $roleruleevaluationdc = str_getcsv($roleruleevaluation);
-        if (!stanford_simplesamlphp_auth_evaulaterolerule($roleruleevaluationdc, $attributes)) {
-          $addnew = FALSE;
-        }
+    foreach ($roleruleevaluations as $roleruleevaluation) {
+      $roleruleevaluationdc = str_getcsv($roleruleevaluation);
+      if (!stanford_simplesamlphp_auth_evaulaterolerule($roleruleevaluationdc, $attributes)) {
+        $addnew = FALSE;
       }
-
-      if ($addnew) {
-        $roles[$roleid] = $roleid;
-      }
-
     }
+
+    if ($addnew) {
+      $roles[$roleid] = $roleid;
+    }
+
   }
 
   return $roles;

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.pages.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.pages.inc
@@ -52,47 +52,4 @@ function stanford_simplesamlphp_auth_loginpage() {
   drupal_goto("user/" . $user->uid);
 
   return;
-
-// The user is not logged into Drupal.
-//  if ($user->uid == 0) {
-//    stanford_simplesaml_auth_login_register();
-//  }
-//  // The user is already logged into Drupal.
-//  else {
-//    stanford_simplesaml_auth_moderate_local_login();
-//  }
-
-  // Support for deep linking.
-
-  // See if a URL has been explicitly provided in ReturnTo. If so, use it (as
-  // long as it points to this site).
-//  if ((isset($_REQUEST['ReturnTo']) && $_REQUEST['ReturnTo']) &&
-//    (valid_url($_REQUEST['ReturnTo']) && stristr($_REQUEST['ReturnTo'], $base_url))) {
-//
-//    $return_to = $_REQUEST['ReturnTo'];
-//
-//    // If not, see if a REFERER URL is available. If so, use it (as long as it
-//    // points to this site).
-//  }
-//  elseif ((isset($_SERVER['HTTP_REFERER']) && $_SERVER['HTTP_REFERER']) &&
-//    (valid_url($_SERVER['HTTP_REFERER']) && stristr($_SERVER['HTTP_REFERER'], $base_url))
-//  ) {
-//
-//    $return_to = $_SERVER['HTTP_REFERER'];
-//  }
-//
-//
-//
-//    // If a ReturnTo has been set.
-//    if ($go_to_url) {
-//      $parsed_gotourl = drupal_parse_url($go_to_url);
-//      drupal_goto($parsed_gotourl['path'], $parsed_gotourl);
-//    }
-//    else {
-//      drupal_goto('user/' . $user->uid);
-//    }
-//
-//  }
-//
-//  return $output;
 }

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.pages.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.pages.inc
@@ -50,6 +50,4 @@ function stanford_simplesamlphp_auth_loginpage() {
 
   // And redirect to somewhere.
   drupal_goto("user/" . $user->uid);
-
-  return;
 }

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -783,10 +783,10 @@ function stanford_ssp_role_mappings_form_validate(array $form, array $form_state
 
   $group = $values['entitlement'];
   try {
-    $members = stanford_ssp_fetch_from_workgroup_api($group);
+    stanford_ssp_fetch_from_workgroup_api($group);
   }
   catch (Exception $e) {
-    form_set_error('entitlement', 'Invalid workgroup.');
+    form_set_error('entitlement', t('Invalid workgroup.'));
   }
 }
 

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -335,7 +335,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
       '#type' => 'textfield',
       '#title' => 'Path to Workgroup API SSL Certificate.',
       '#default_value' => $cert_filename,
-      '#description' => 'For more information on how to get a certificate please see: https://uit.stanford.edu/service/registry/certificates',
+      '#description' => t('For more information on how to get a certificate please see: https://uit.stanford.edu/service/registry/certificates'),
       '#states' => array(
         'visible' => array(
           ':input[name="stanford_ssp_role_map_source"]' => array('value' => 'workgroup'),
@@ -347,7 +347,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
       '#type' => 'textfield',
       '#title' => 'Path to Workgroup API SSL Key.',
       '#default_value' => $key_filename,
-      '#description' => 'For more information on how to get a key please see: https://uit.stanford.edu/service/registry/certificates',
+      '#description' => t('For more information on how to get a key please see: https://uit.stanford.edu/service/registry/certificates'),
       '#states' => array(
         'visible' => array(
           ':input[name="stanford_ssp_role_map_source"]' => array('value' => 'workgroup'),
@@ -357,7 +357,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
 
   }
   else {
-    $form['no_open_ssl'] = array (
+    $form['no_open_ssl'] = array(
       '#type' => 'container',
       '#states' => array(
         'visible' => array(

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -404,7 +404,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
 
   $header = array(
     t('Drupal Role'),
-    t('Workgroup (e.g. anchorage:humanbiology-admins)'),
+    t('Workgroup (e.g. helpdesk:consultants)'),
     t('Action'),
   );
 
@@ -794,7 +794,7 @@ function stanford_ssp_role_mappings_form_validate(array $form, array $form_state
  * Maps an entitlement to a role.
  *
  * @param string $entitlement
- *   A value in eduPersonEntitlement, e.g., anchorage:support.
+ *   A value in eduPersonEntitlement, e.g., helpdesk:consultants.
  * @param mixed $role
  *   Either the role id or a name.
  */

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -357,7 +357,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
 
   $header = array(
     t('Drupal Role'),
-    t('Workgroup (e.g. anchorage_humanbiology-admins)'),
+    t('Workgroup (e.g. anchorage:humanbiology-admins)'),
     t('Action'),
   );
 
@@ -716,7 +716,7 @@ function stanford_ssp_role_mappings_form_submit(array $form, array &$form_state)
  * Maps an entitlement to a role.
  *
  * @param string $entitlement
- *   A value in eduPersonEntitlement, e.g., anchorage_support.
+ *   A value in eduPersonEntitlement, e.g., anchorage:support.
  * @param mixed $role
  *   Either the role id or a name.
  */

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -1,16 +1,22 @@
 <?php
-/**
- * @file config forms.
- */
 
+/**
+ * @file
+ * Config forms.
+ */
 
 /**
  * The main landing page for the configuration form.
- * @param  [type] $form        [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ *
+ * @param array $form
+ *   Form array.
+ * @param array &$form_state
+ *   Form state array.
+ *
+ * @return array
+ *   The form array.
  */
-function stanford_ssp_configuration_form($form, &$form_state) {
+function stanford_ssp_configuration_form(array $form, array &$form_state) {
 
   // Vertical Tab container.
   $form['togglers'] = array(
@@ -18,8 +24,8 @@ function stanford_ssp_configuration_form($form, &$form_state) {
     '#default_tab' => 'edit-general-config',
   );
 
-  // Tab Groups
-  // ----------------------------------------------------------------
+  // Tab Groups.
+  // ----------------------------------------------------------------.
 
   // Tab for the general options.
   $form['general-config'] = array(
@@ -49,7 +55,7 @@ function stanford_ssp_configuration_form($form, &$form_state) {
   );
 
   // General Config
-  // ---------------------------------------------------------------
+  // ---------------------------------------------------------------.
 
   // Enables / Disables user authentication by simplesamlphp.
   $form['general-config']['stanford_simplesamlphp_auth_activate'] = array(
@@ -83,7 +89,7 @@ function stanford_ssp_configuration_form($form, &$form_state) {
     '#description' => t("Enforce that authentication and authenticated transactions happen over HTTPS. This should be enabled on production websites."),
   );
 
-  // Reformat entitlements, replacing : with _
+  // Reformat entitlements, replacing : with _.
   $form['general-config']['stanford_ssp_format_entitlements'] = array(
     '#type' => 'switch',
     '#title' => t('Reformat entitlements.'),
@@ -91,7 +97,7 @@ function stanford_ssp_configuration_form($form, &$form_state) {
     '#description' => t("If your SP configuration reformats entitlements (e.g. stanford:stanford to stanford_stanford), enable this option."),
   );
 
-  $form['general-config'] ['stanford_ssp_redirect_on_login'] = array(
+  $form['general-config']['stanford_ssp_redirect_on_login'] = array(
     '#type' => 'textfield',
     '#title' => t('Redirect all users on successful login to this url.'),
     '#default_value' => variable_get('stanford_ssp_redirect_on_login', FALSE),
@@ -99,7 +105,7 @@ function stanford_ssp_configuration_form($form, &$form_state) {
   );
 
   // User Config
-  // ------------------------------------------------------------------
+  // ------------------------------------------------------------------.
 
   // Auto create an account for users on auth.
   $form['user-config']['stanford_simplesamlphp_auth_registerusers'] = array(
@@ -138,7 +144,7 @@ function stanford_ssp_configuration_form($form, &$form_state) {
   );
 
   // SAML Config
-  // ------------------------------------------------------------------
+  // ------------------------------------------------------------------.
 
   $form['saml-config']['stanford_simplesamlphp_auth_installdir'] = array(
     '#type' => 'textfield',
@@ -180,14 +186,18 @@ function stanford_ssp_configuration_form($form, &$form_state) {
   return system_settings_form($form);
 }
 
-
 /**
  * Authorization and authentication settings form.
- * @param  [type] $form        [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
+ *
+ * @return array
+ *   The form array.
  */
-function stanford_ssp_authorizations_form($form, &$form_state) {
+function stanford_ssp_authorizations_form(array $form, array &$form_state) {
 
   // Vertical Tab container.
   $form['togglers'] = array(
@@ -196,7 +206,7 @@ function stanford_ssp_authorizations_form($form, &$form_state) {
   );
 
   // Tab Groups
-  // ----------------------------------------------------------------
+  // ----------------------------------------------------------------.
 
   // Tab for the general options.
   $form['saml-config'] = array(
@@ -215,7 +225,7 @@ function stanford_ssp_authorizations_form($form, &$form_state) {
   );
 
   // SSO AUTH CONFIG
-  // -------------------------------------------------------------------
+  // -------------------------------------------------------------------.
 
   $options = array(
     'any' => t("Allow any valid SSO (SUNet) user."),
@@ -254,7 +264,7 @@ function stanford_ssp_authorizations_form($form, &$form_state) {
   );
 
   // LOCAL AUTH CONFIG
-  // -------------------------------------------------------------------
+  // -------------------------------------------------------------------.
 
   $roles = user_roles(TRUE);
   $form['local-config']['stanford_simplesamlphp_auth_allowdefaultloginroles'] = array(
@@ -298,14 +308,23 @@ function stanford_ssp_role_mappings_form($form, &$form_state) {
     '#default_value' => variable_get("stanford_ssp_auth_role_map", 'none'),
   );
 
-  // ROLE MAPPING FORM.
+  $form['stanford_ssp_role_map_source'] = array(
+    '#type' => 'radios',
+    '#title' => 'Source to validate role mapping groups against.',
+    '#options' => array(
+      'workgroup' => t('Workgroup API'),
+      'entitlement' => t('eduPersonEntitlement attribute'),
+    ),
+    '#default_value' => variable_get("stanford_ssp_role_map_source", 'entitlement'),
+  );
 
+  // ROLE MAPPING FORM.
   $table = array();
   $submitted = !empty($form_state['post']);
-  $roles = user_roles(TRUE);
-  // Remove authenticated user has this will be defaulted to true.
-  unset($roles[2]);
 
+  // Remove authenticated user has this will be defaulted to true.
+  $roles = user_roles(TRUE);
+  unset($roles[2]);
 
   $form['role_id'] = array(
     '#name' => 'role_id',
@@ -325,12 +344,16 @@ function stanford_ssp_role_mappings_form($form, &$form_state) {
     '#value' => t('Add Mapping'),
   );
 
-  $table[] = array(drupal_render($form['role_id']), drupal_render($form['entitlement']), drupal_render($form['new_submit']));
+  $table[] = array(
+    drupal_render($form['role_id']),
+    drupal_render($form['entitlement']),
+    drupal_render($form['new_submit']),
+  );
 
   $header = array(
     t('Drupal Role'),
     t('Workgroup (e.g. anchorage_humanbiology-admins)'),
-    t('Action')
+    t('Action'),
   );
 
   $rolemaps = variable_get("stanford_simplesamlphp_auth_rolepopulation", "");
@@ -385,48 +408,55 @@ function stanford_ssp_role_mappings_form($form, &$form_state) {
   return system_settings_form($form);
 }
 
-
 /**
  * The login block and forms form form.
- * @param  [type] $form        [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
+ *
+ * @return array
+ *   The form array.
  */
-function stanford_ssp_login_block_forms_form($form, &$form_state) {
+function stanford_ssp_login_block_forms_form(array $form, array &$form_state) {
 
   $form['stanford_ssp_show_local_login'] = array(
     '#type' => 'switch',
     '#title' => t('Show the local login form on the user page'),
     '#default_value' => variable_get('stanford_ssp_show_local_login', TRUE),
-    '#description' => t("Turn on to show the local Drupal account login option on the !link.", array("!link" => l("user page", "user"))),
+    '#description' => t("Turn on to show the local Drupal account login option on the !link.", array("!link" => l(t("user page"), "user"))),
   );
 
   $form['stanford_ssp_show_sso_login'] = array(
     '#type' => 'switch',
     '#title' => t('Show the SSO login link on user page'),
     '#default_value' => variable_get('stanford_ssp_show_sso_login', TRUE),
-    '#description' => t("Turn on to show the SSO login link on the !link.", array("!link" => l("user page", "user"))),
+    '#description' => t("Turn on to show the SSO login link on the !link.", array("!link" => l(t("user page"), "user"))),
   );
 
   $form['stanford_ssp_sso_link_text'] = array(
     '#type' => 'textfield',
     '#title' => t('SSO login link text'),
     '#default_value' => variable_get('stanford_ssp_sso_link_text', t("Log in with your SUNet ID »")),
-    '#description' => t("Override the link text for the SSO login link on the !link.", array("!link" => l("user page", "user"))),
+    '#description' => t("Override the link text for the SSO login link on the !link.", array("!link" => l(t("user page"), "user"))),
   );
-
 
   return system_settings_form($form);
 }
 
-
 /**
  * Add a new SSO user account.
- * @param  [type] $form        [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
+ *
+ * @return array
+ *   The form array.
  */
-function stanford_ssp_add_sso_user($form, &$form_state) {
+function stanford_ssp_add_sso_user(array $form, array &$form_state) {
 
   $form['sunetid'] = array(
     '#type' => 'textfield',
@@ -435,20 +465,20 @@ function stanford_ssp_add_sso_user($form, &$form_state) {
     '#required' => TRUE,
   );
 
-  $form['name']  = array(
+  $form['name'] = array(
     '#type' => 'textfield',
     '#title' => t('Name'),
-    '#description' => t('If you wish to specify the user\'s preferred name (instead of sunetid@stanford.edu), enter it here.'),
+    '#description' => t("If you wish to specify the user's preferred name (instead of sunetid@stanford.edu), enter it here."),
   );
 
-  $form['email']  = array(
+  $form['email'] = array(
     '#type' => 'textfield',
     '#title' => t('Email Address'),
     '#description' => t('If you wish to specify an alternate email address (instead of sunetid@stanford.edu), enter it here.'),
   );
 
-  $roles = user_roles(TRUE);
   // Remove authenticated user has this will be defaulted to true.
+  $roles = user_roles(TRUE);
   unset($roles[2]);
 
   // Only show the option if there is an option.
@@ -492,8 +522,13 @@ function stanford_ssp_add_sso_user($form, &$form_state) {
 
 /**
  * Validation function for stanford_ssp_configuration_form().
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
  */
-function stanford_ssp_configuration_form_validate($form, &$form_state) {
+function stanford_ssp_configuration_form_validate(array $form, array &$form_state) {
   $values = $form_state['values'];
 
   // Prevent both ssp and local login options from being disabled.
@@ -505,9 +540,14 @@ function stanford_ssp_configuration_form_validate($form, &$form_state) {
 }
 
 /**
- * Validation function for Add WebAuth User form
+ * Validation function for Add WebAuth User form.
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
  */
-function stanford_ssp_add_sso_user_validate($form, &$form_state) {
+function stanford_ssp_add_sso_user_validate(array $form, array &$form_state) {
 
   $sunet = strtolower(trim(check_plain($form_state['values']['sunetid'])));
 
@@ -525,7 +565,7 @@ function stanford_ssp_add_sso_user_validate($form, &$form_state) {
   // If no name is specified, use the default name (sunetid + @stanford.edu).
   $name = trim(check_plain($form_state['values']['name']));
   if (empty($name)) {
-    $name  = $authname;
+    $name = $authname;
   }
 
   // Check that there is no user with the same name.
@@ -569,7 +609,6 @@ function stanford_ssp_authorizations_form_validate(&$form, &$form_state) {
   form_set_value($form['saml-config']['stanford_ssp_auth_restriction_group'], $workgroups, $form_state);
 }
 
-
 /**
  * ***************************************************************
  * SUBMIT FUNCTIONS
@@ -578,11 +617,13 @@ function stanford_ssp_authorizations_form_validate(&$form, &$form_state) {
 
 /**
  * Submit handler for stanford_ssp_add_sso_user form.
- * @param  [type] &$form       [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
  */
-function stanford_ssp_add_sso_user_submit(&$form, &$form_state) {
+function stanford_ssp_add_sso_user_submit(array &$form, array &$form_state) {
 
   // Sunet.
   $sunet = strtolower(trim(check_plain($form_state['values']['sunetid'])));
@@ -591,7 +632,7 @@ function stanford_ssp_add_sso_user_submit(&$form, &$form_state) {
   // If no name is specified, use the default name (sunetid + @stanford.edu).
   $name = trim(check_plain($form_state['values']['name']));
   if (empty($name)) {
-    $name  = $authname;
+    $name = $authname;
   }
 
   // Email and default.
@@ -609,7 +650,7 @@ function stanford_ssp_add_sso_user_submit(&$form, &$form_state) {
   $account->init = $sunet . '@stanford.edu';
   $account->status = TRUE;
   $roles = array(
-    DRUPAL_AUTHENTICATED_RID => TRUE
+    DRUPAL_AUTHENTICATED_RID => TRUE,
   );
 
   // Add in roles from config form.
@@ -650,13 +691,9 @@ function stanford_ssp_add_sso_user_submit(&$form, &$form_state) {
 }
 
 /**
- *
  * Implements hook_form_submit().
- *
- * @param $form
- * @param $form_state
  */
-function stanford_ssp_role_mappings_form_submit($form, &$form_state) {
+function stanford_ssp_role_mappings_form_submit(array $form, array &$form_state) {
 
   $entitlement = $form_state['values']['entitlement'];
   $role = $form_state['values']['role_id'];
@@ -680,8 +717,8 @@ function stanford_ssp_role_mappings_form_submit($form, &$form_state) {
  */
 function stanford_ssp_map_entitlement_to_role($entitlement, $role) {
   $entitlement = check_plain($entitlement);
-  // Look up rid.
 
+  // Look up rid.
   $role_object = FALSE;
   if (is_numeric($role)) {
     $role_object = user_role_load($role);
@@ -702,6 +739,7 @@ function stanford_ssp_map_entitlement_to_role($entitlement, $role) {
     }
     // Add our mapping.
     $role_mapping .= $rid . ":eduPersonEntitlement,=," . $entitlement;
+
     // Save our mapping.
     variable_set('stanford_simplesamlphp_auth_rolepopulation', $role_mapping);
     $message = t('Mapped the "@entitlement" entitlement to the "@role" role.', array('@entitlement' => $entitlement, '@role' => $role_object->name));
@@ -711,10 +749,14 @@ function stanford_ssp_map_entitlement_to_role($entitlement, $role) {
 }
 
 /**
- * @param $form
- * @param $form_state
+ * Remove waird formatting.
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
  */
-function stanford_ssp_remove_waird($form, &$form_state) {
+function stanford_ssp_remove_waird(array $form, array &$form_state) {
   $trigger = $form_state["triggering_element"]['#name'];
   $index = $form_state['values'][$trigger . "_value"];
   $rolemaps = variable_get("stanford_simplesamlphp_auth_rolepopulation", array());
@@ -726,9 +768,3 @@ function stanford_ssp_remove_waird($form, &$form_state) {
   variable_set("stanford_simplesamlphp_auth_rolepopulation", $imp);
   drupal_set_message(t("Role mapping was removed"));
 }
-
-/**
- * *****************************************************************
- * HELPER / UTIL
- * *****************************************************************
- */

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -334,7 +334,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
     $form['stanford_ssp_workgroup_api_cert'] = array(
       '#type' => 'textfield',
       '#title' => 'Path to Workgroup API SSL Certificate.',
-      '#default_value' => $cert_filename,
+      '#default_value' => !empty($cert_filename) ? $cert_filename : $default_path . "/stanford-ssp.cert",
       '#description' => t('For more information on how to get a certificate please see: https://uit.stanford.edu/service/registry/certificates'),
       '#states' => array(
         'visible' => array(
@@ -346,7 +346,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
     $form['stanford_ssp_workgroup_api_key'] = array(
       '#type' => 'textfield',
       '#title' => 'Path to Workgroup API SSL Key.',
-      '#default_value' => $key_filename,
+      '#default_value' => !empty($key_filename) ? $key_filename : $default_path . "/stanford-ssp.key",
       '#description' => t('For more information on how to get a key please see: https://uit.stanford.edu/service/registry/certificates'),
       '#states' => array(
         'visible' => array(
@@ -356,6 +356,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
     );
 
   }
+  // If OpenSSL is not available then we should inform the end user.
   else {
     $form['no_open_ssl'] = array(
       '#type' => 'container',

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -388,7 +388,6 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
   $form['entitlement'] = array(
     '#name' => 'entitlement',
     '#type' => 'textfield',
-    '#default_value' => '',
   );
 
   $form['new_submit'] = array(
@@ -458,6 +457,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
 
   // END ROLE MAPPING FORM.
   $form["#submit"][] = "stanford_ssp_role_mappings_form_submit";
+  $form["#validate"][] = "stanford_ssp_role_mappings_form_validate";
   return system_settings_form($form);
 }
 
@@ -758,6 +758,36 @@ function stanford_ssp_role_mappings_form_submit(array $form, array &$form_state)
     stanford_ssp_map_entitlement_to_role($entitlement, $role);
   }
 
+}
+
+/**
+ * Validate the workgroup against the api if that mapping is available.
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
+ */
+function stanford_ssp_role_mappings_form_validate(array $form, array $form_state) {
+
+  // Only validate if the api setting is set.
+  $values = $form_state['values'];
+  if ($values['stanford_ssp_role_map_source'] !== "workgroup") {
+    return;
+  }
+
+  // If we were sent a new entitlement validate it.
+  if (empty($values['entitlement'])) {
+    return;
+  }
+
+  $group = $values['entitlement'];
+  try {
+    $members = stanford_ssp_fetch_from_workgroup_api($group);
+  }
+  catch (Exception $e) {
+    form_set_error('entitlement', 'Invalid workgroup.');
+  }
 }
 
 /**

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -323,6 +323,53 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
     '#default_value' => variable_get("stanford_ssp_role_map_source", 'entitlement'),
   );
 
+  // In order to make this request openssl has to be available to php.
+  if (function_exists('openssl_get_cert_locations')) {
+    // Add the SSL certificate paths.
+    $openssl_defaults = openssl_get_cert_locations();
+    $default_path = $openssl_defaults['default_cert_dir'];;
+    $cert_filename = variable_get('stanford_ssp_workgroup_api_cert', $default_path . "/stanford-ssp.cert");
+    $key_filename = variable_get('stanford_ssp_workgroup_api_key', $default_path . "/stanford-ssp.key");
+
+    $form['stanford_ssp_workgroup_api_cert'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Path to Workgroup API SSL Certificate.',
+      '#default_value' => $cert_filename,
+      '#description' => 'For more information on how to get a certificate please see: https://uit.stanford.edu/service/registry/certificates',
+      '#states' => array(
+        'visible' => array(
+          ':input[name="stanford_ssp_role_map_source"]' => array('value' => 'workgroup'),
+        ),
+      ),
+    );
+
+    $form['stanford_ssp_workgroup_api_key'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Path to Workgroup API SSL Key.',
+      '#default_value' => $key_filename,
+      '#description' => 'For more information on how to get a key please see: https://uit.stanford.edu/service/registry/certificates',
+      '#states' => array(
+        'visible' => array(
+          ':input[name="stanford_ssp_role_map_source"]' => array('value' => 'workgroup'),
+        ),
+      ),
+    );
+
+  }
+  else {
+    $form['no_open_ssl'] = array (
+      '#type' => 'container',
+      '#states' => array(
+        'visible' => array(
+          ':input[name="stanford_ssp_role_map_source"]' => array('value' => 'workgroup'),
+        ),
+      ),
+    );
+    $form['no_open_ssl']['no_open_ssl_message'] = array(
+      '#markup' => '<div class="messages message error"><h2>OpenSSL is not available. Please compile PHP with OpenSSL to use workgroup api validation.</h2></div>',
+    );
+  }
+
   // ROLE MAPPING FORM.
   $table = array();
   $submitted = !empty($form_state['post']);

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -289,11 +289,16 @@ function stanford_ssp_authorizations_form(array $form, array &$form_state) {
 
 /**
  * Role mapping form for mapping a role to an authenticated user.
- * @param  [type] $form        [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ *
+ * @param array $form
+ *   The form array.
+ * @param array &$form_state
+ *   The form state array.
+ *
+ * @return array
+ *   The form array.
  */
-function stanford_ssp_role_mappings_form($form, &$form_state) {
+function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
 
   $options = array(
     'none' => t("Do not adjust roles. Allow local administration of roles only."),
@@ -313,7 +318,7 @@ function stanford_ssp_role_mappings_form($form, &$form_state) {
     '#title' => 'Source to validate role mapping groups against.',
     '#options' => array(
       'workgroup' => t('Workgroup API'),
-      'entitlement' => t('eduPersonEntitlement attribute'),
+      'entitlement' => t('SAML attribute'),
     ),
     '#default_value' => variable_get("stanford_ssp_role_map_source", 'entitlement'),
   );

--- a/stanford_ssp.drush.inc
+++ b/stanford_ssp.drush.inc
@@ -16,7 +16,7 @@ function stanford_ssp_drush_command() {
   $items['saml-entitlement-role'] = array(
     'description' => 'Map a SAML entitlement to a role',
     'arguments' => array(
-      'entitlement' => 'A value from eduPersonEntitlement, e.g., "anchorage_support"',
+      'entitlement' => 'A value from eduPersonEntitlement, e.g., "anchorage:support"',
       'role' => 'The name of the role, e.g., "administrator"',
     ),
     'aliases' => array('ssp-ser'),

--- a/stanford_ssp.drush.inc
+++ b/stanford_ssp.drush.inc
@@ -16,7 +16,7 @@ function stanford_ssp_drush_command() {
   $items['saml-entitlement-role'] = array(
     'description' => 'Map a SAML entitlement to a role',
     'arguments' => array(
-      'entitlement' => 'A value from eduPersonEntitlement, e.g., "anchorage:support"',
+      'entitlement' => 'A value from eduPersonEntitlement, e.g., "helpdesk:consultants"',
       'role' => 'The name of the role, e.g., "administrator"',
     ),
     'aliases' => array('ssp-ser'),

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -18,7 +18,6 @@ function stanford_ssp_install() {
   variable_set('stanford_simplesamlphp_auth_autoenablesaml', TRUE);
   variable_set('stanford_ssp_prevent_cache', FALSE);
   variable_set('stanford_simplesamlphp_auth_allowsetdrupalpwd', FALSE);
-  variable_set('stanford_simplesamlphp_auth_installdir', '/opt/simplesamlphp');
   variable_set('stanford_simplesamlphp_auth_authsource', 'default-sp');
   variable_set('stanford_simplesamlphp_auth_user_name', 'displayName');
   variable_set('stanford_simplesamlphp_auth_unique_id', 'uid');
@@ -80,6 +79,7 @@ function stanford_ssp_uninstall() {
   variable_del('stanford_ssp_show_sso_login');
   variable_del('stanford_ssp_sso_link_text');
   variable_del('stanford_ssp_debug');
+  variable_del('stanford_ssp_role_map_source');
 }
 
 /**

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -80,6 +80,9 @@ function stanford_ssp_uninstall() {
   variable_del('stanford_ssp_sso_link_text');
   variable_del('stanford_ssp_debug');
   variable_del('stanford_ssp_role_map_source');
+  variable_del('stanford_ssp_workgroup_api_cert');
+  variable_del('stanford_ssp_workgroup_api_key');
+  variable_del('stanford_ssp_workgroup_api_endpoint');
 }
 
 /**

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -932,6 +932,40 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
     return array();
   }
 
+  try {
+    $values = stanford_ssp_fetch_from_workgroup_api($group);
+  }
+  catch (Exception $e) {
+    // Return nothing.
+    return array();
+  }
+
+  if (empty($values['members'])) {
+    return array();
+  }
+
+  $members = array();
+  foreach ($values['members']['member'] as $member) {
+    try {
+      $members[] = stanford_ssp_get_api_members_from_xml_array($member);
+    }
+    catch (Exception $e) {
+      watchdog('stanford_ssp', $e->getMessage(), array(), WATCHDOG_DEBUG);
+    }
+  }
+
+  return array_unique($members);
+}
+
+/**
+ * Makes a call to the workgroup endpoint via curl.
+ *
+ * Fetch the group information from the configured endpoint.
+ *
+ * @param string $group
+ *   The workgroup to look up.
+ */
+function stanford_ssp_fetch_from_workgroup_api($group = "") {
   // Workgroup endpoint. Needs and installed SSL cert to work.
   // UAT server is at: https://workgroupsvc-uat.stanford.edu/v1/workgroups/
   $endpoint = variable_get('stanford_ssp_workgroup_api_endpoint', 'https://aswsweb.stanford.edu/mais/workgroupsvc/v1/workgroups/');
@@ -967,12 +1001,12 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
 
   if ($curl_info['http_code'] !== 200) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
-    return array();
+    throw new Exception("Error fetching workgroup api information.");
   }
 
   if (empty($response) || ($err == 0 && !empty($errmsg))) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
-    return array();
+    throw new Exception($errmsg);
   }
 
   // We have a valid response. Load up the xml and parse out the users.
@@ -980,16 +1014,7 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
   $json = json_encode($xml);
   $values = json_decode($json, TRUE);
 
-  $members = array();
-  foreach ($values['members']['member'] as $member) {
-    $members[] = stanford_ssp_get_api_members_from_xml_array($member);
-  }
-
-  foreach ($values['administrators']['member'] as $member) {
-    $members[] = stanford_ssp_get_api_members_from_xml_array($member);
-  }
-
-  return array_unique($members);
+  return $values;
 }
 
 /**
@@ -1002,6 +1027,9 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
  *   Sunet id.
  */
 function stanford_ssp_get_api_members_from_xml_array(array $member) {
+  if (!isset($member['@attributes'])) {
+    throw new Exception("Invalid member attribute data");
+  }
   return $member['@attributes']['id'];
 }
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -962,7 +962,13 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
   $response = curl_exec($ch);
   $err = curl_errno($ch);
   $errmsg = curl_error($ch);
+  $curl_info = curl_getinfo($ch);
   curl_close($ch);
+
+  if ($curl_info['http_code'] !== 200) {
+    watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
+    return array();
+  }
 
   if (empty($response) || ($err == 0 && !empty($errmsg))) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -933,23 +933,49 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
   }
 
   // Workgroup endpoint. Needs and installed SSL cert to work.
+  // UAT server is at: https://workgroupsvc-uat.stanford.edu/v1/workgroups/
   $endpoint = variable_get('stanford_ssp_workgroup_api_endpoint', 'https://workgroupsvc.stanford.edu/v1/workgroups/');
   $endpoint .= $group;
 
-  $response = drupal_http_request($endpoint, array('timeout' => 5));
+  // In order to make this request openssl has to be available to php.
+  if (!function_exists('openssl_get_cert_locations')) {
+    throw new Exception("PHP must be compiled with Openssl in order for workgroup api validation to work.");
+  }
 
-  if ($response->code !== "200") {
+  // Add the SSL certificate paths.
+  $openssl_defaults = openssl_get_cert_locations();
+  $default_path = $openssl_defaults['default_cert_dir'];
+  $cert_filename = variable_get('stanford_ssp_workgroup_api_cert', $default_path . "/stanford-ssp.cert");
+  $key_filename = variable_get('stanford_ssp_workgroup_api_key', $default_path . "/stanford-ssp.key");
+
+  $ch = curl_init();
+  curl_setopt($ch, CURLOPT_URL, $endpoint);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+  curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+  curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+  curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+  curl_setopt($ch, CURLOPT_SSLKEY, $key_filename);
+  curl_setopt($ch, CURLOPT_SSLCERT, $cert_filename);
+
+  $response = curl_exec($ch);
+  $err = curl_errno($ch);
+  $errmsg = curl_error($ch);
+  curl_close($ch);
+
+  if (empty($response) || ($err == 0 && !empty($errmsg) )) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
     return array();
   }
 
   // We have a valid response. Load up the xml and parse out the users.
-  $xml = simplexml_load_string($response->data);
+  $xml = simplexml_load_string($response);
   $json = json_encode($xml);
   $values = json_decode($json, TRUE);
 
   $members = array();
-  foreach ($values['administrators']['member'] as $member) {
+  foreach ($values['members']['member'] as $member) {
     $members[] = stanford_ssp_get_api_members_from_xml_array($member);
   }
 
@@ -970,7 +996,7 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
  *   Sunet id.
  */
 function stanford_ssp_get_api_members_from_xml_array(array $member) {
-  return $member['@attributes']['name'];
+  return $member['@attributes']['id'];
 }
 
 /**

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -918,7 +918,7 @@ function stanford_ssp_validate_workgroup_by_api($sunet, array $groups) {
  * Get an array of sunet ids in a workgroup.
  *
  * @param string $group
- *   The workgroup name. eg: `mais:test`.
+ *   The workgroup name. eg: "helpdesk:consultants".
  *
  * @return array
  *   An array of members for the passed in workgroup.
@@ -966,7 +966,7 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
  *   The workgroup to look up.
  */
 function stanford_ssp_fetch_from_workgroup_api($group = "") {
-  // Workgroup endpoint. Needs and installed SSL cert to work.
+  // Workgroup endpoint. Needs an installed SSL cert to work.
   // UAT server is at: https://workgroupsvc-uat.stanford.edu/v1/workgroups/
   $endpoint = variable_get('stanford_ssp_workgroup_api_endpoint', 'https://aswsweb.stanford.edu/mais/workgroupsvc/v1/workgroups/');
   $endpoint .= $group;

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -394,7 +394,7 @@ function stanford_ssp_user_delete($account) {
 }
 
 /**
- * Implements hook_stanford_simplesamlphp_auth_allow_login.
+ * Implements hook_stanford_simplesamlphp_auth_allow_login().
  *
  * @param array $attributes
  *   SAML Attributes.

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -938,7 +938,7 @@ function stanford_ssp_validate_workgroup_by_api($sunet, array $groups) {
 function stanford_ssp_get_workgroup_members_by_api($group) {
 
   // Validate group name. Needs to be in the format 'something:something'.
-  $xp = explode($group, ":");
+  $xp = explode(":", $group);
   if (count($xp) !== 2) {
     watchdog('stanford_ssp', 'Invalid workgroup format.', array(), WATCHDOG_ERROR);
     return array();

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -466,7 +466,7 @@ function stanford_ssp_simplesamlphp_auth_allow_login_validate_groups(array $grou
 
   switch ($method) {
     case "workgroup":
-      $sunet = array_pop($attributes['uid']);
+      $sunet = array_pop($attributes[variable_get('stanford_simplesamlphp_auth_unique_id', 'eduPersonPrincipalName')]);
       $result = stanford_ssp_validate_workgroup_by_api($sunet, $groups);
       break;
 
@@ -598,11 +598,13 @@ function stanford_ssp_auth_role_map_person_affiliation(&$user) {
 
 /**
  * User account form.
- * @param  [type] &$form       [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ *
+ * @param array $form
+ *   The form array.
+ * @param array &$form_state
+ *   The form state array.
  */
-function stanford_ssp_form_user_profile_form_alter(&$form, &$form_state) {
+function stanford_ssp_form_user_profile_form_alter(array &$form, array &$form_state) {
 
   // Check for editing a user. If we don't have a user we can end.
   $account = isset($form["#user"]) ? $form["#user"] : FALSE;
@@ -626,11 +628,12 @@ function stanford_ssp_form_user_profile_form_alter(&$form, &$form_state) {
 /**
  * Implements hook_form_FORMID_alter().
  *
- * @param  [type] &$form       [description]
- * @param  [type] &$form_state [description]
- * @return [type]              [description]
+ * @param array $form
+ *   The form array.
+ * @param array &$form_state
+ *   The form state array.
  */
-function stanford_ssp_form_user_login_alter(&$form, &$form_state) {
+function stanford_ssp_form_user_login_alter(array &$form, array &$form_state) {
 
   // Check for https forcing:
   stanford_ssp_force_https();
@@ -686,21 +689,25 @@ function stanford_ssp_form_user_login_alter(&$form, &$form_state) {
 
 /**
  * Implements hook form alter.
- * @param  [type] $form       [description]
- * @param  [type] $form_state [description]
- * @return [type]             [description]
+ *
+ * @param array $form
+ *   The form array.
+ * @param array &$form_state
+ *   The form state array.
  */
-function stanford_ssp_form_user_pass_alter(&$form, &$form_state) {
+function stanford_ssp_form_user_pass_alter(array &$form, array &$form_state) {
   $form["#validate"][] = "stanford_ssp_form_user_pass_alter_validate";
 }
 
 /**
  * Prevent password reset from working if local accounts turned off.
- * @param  [type] $form       [description]
- * @param  [type] $form_state [description]
- * @return [type]             [description]
+ *
+ * @param array $form
+ *   The form array.
+ * @param array $form_state
+ *   The form state array.
  */
-function stanford_ssp_form_user_pass_alter_validate($form, $form_state) {
+function stanford_ssp_form_user_pass_alter_validate(array $form, array $form_state) {
   if (!variable_get("stanford_simplesamlphp_auth_allowdefaultlogin", TRUE)) {
     form_set_error("", t("We're sorry but local account login has been disabled. Password reset is not available at this time."));
   }
@@ -886,7 +893,8 @@ function stanford_ssp_convert_webauth_role_mappings() {
     $roles = explode('|', $rolepop);
   }
   foreach ($webauth_roles as $mapping) {
-    // stanford_simplesamlphp_auth_rolepopulation = $rid:eduPersonEntitlement,=,$workgroup|$rid:eduPersonEntitlement,=,$workgroup
+    // stanford_simplesamlphp_auth_rolepopulation
+    // eg: $rid:eduPersonEntitlement,=,$workgroup
     // Replace colons with underscores.
     $workgroup = stanford_ssp_format_entitlement($mapping->wa_group);
     $roles[] = $mapping->rid . ":eduPersonEntitlement,=," . $workgroup;
@@ -978,12 +986,15 @@ function stanford_ssp_get_api_members_from_xml_array(array $member) {
 }
 
 /**
- * [stanford_ssp_sample_workgroup_response description]
- * @return [type] [description]
+ * Fake or test workgroup api response.
+ *
+ * This fake endpoint response is derived from the example found at:
+ * https://web.stanford.edu/dept/as/mais/applications/workgroupapi/api.html.
+ *
+ * This should only be used for testing and not real authentication.
  */
 function stanford_ssp_sample_workgroup_response() {
 
-  // drupal_add_http_header('Content-Disposition', 'attachment; filename="mais:test.xml"');
   drupal_add_http_header('Content-Type', 'text/xml;charset=UTF-8');
 
   $response = <<<EOD

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -934,7 +934,7 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
 
   // Workgroup endpoint. Needs and installed SSL cert to work.
   // UAT server is at: https://workgroupsvc-uat.stanford.edu/v1/workgroups/
-  $endpoint = variable_get('stanford_ssp_workgroup_api_endpoint', 'https://workgroupsvc.stanford.edu/v1/workgroups/');
+  $endpoint = variable_get('stanford_ssp_workgroup_api_endpoint', 'https://aswsweb.stanford.edu/mais/workgroupsvc/v1/workgroups/');
   $endpoint .= $group;
 
   // In order to make this request openssl has to be available to php.

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -7,13 +7,10 @@
 /**
  * Implements hook_menu().
  */
-
 function stanford_ssp_menu() {
   $items = array();
 
-  // Authpoint
-  // ---------
-
+  // Authpoint.
   $items['sso/login'] = array(
     'title' => "Stanford SSO Authentication Endpoint",
     'description' => "Authentication endpoint.",
@@ -24,13 +21,18 @@ function stanford_ssp_menu() {
   $items['sso/denied-test'] = array(
     'title' => "Always denied",
     'description' => "Authentication endpoint test.",
+    'page callback' => 'stanford_ssp_sample_workgroup_response',
+  );
+
+  $items['sso/workgroup-test'] = array(
+    'title' => "Workgroup XML sample response",
+    'description' => "Workgroup data test.",
     'page callback' => 'stanford_ssp_sso_auth',
     'access callback' => FALSE,
   );
 
   // Configuration Forms
-  // -------------------
-
+  // -------------------.
   $items['admin/config/stanford/stanford_ssp'] = array(
     'title' => "Stanford SSO",
     'description' => "Stanford Single Sign On configuration settings.",
@@ -122,7 +124,7 @@ function stanford_ssp_permission() {
 }
 
 /**
- * Custom access callback to validate user's access to login page sso/login
+ * Custom access callback to validate user's access to login page sso/login.
  */
 function stanford_ssp_access_login_page() {
 
@@ -223,7 +225,6 @@ function stanford_ssp_sso_auth() {
  *
  * Checks to ensure user is on https and will force redirect if option is on.
  * Also enforces secure cookies on https.
- *
  */
 function stanford_ssp_force_https() {
 
@@ -256,7 +257,7 @@ function stanford_ssp_force_https() {
  * @param array &$page
  *   The page render array.
  */
-function stanford_ssp_page_build(&$page) {
+function stanford_ssp_page_build(array &$page) {
   // We don't want to mess with the 403 page setting so we should check the
   // header response on the page build.
   $headers = drupal_get_http_header();
@@ -274,37 +275,35 @@ function stanford_ssp_page_build(&$page) {
   }
 }
 
-
 /**
  * Provide a different lookup mechanism other than by user name.
+ *
  * Needs a patch from https://www.drupal.org/node/2635152 in order for this
  * hook to exist. Without this hook, only username works for lookup.
  *
  * @param object $ext_user
  *    A loaded user object.
- * @param array $_simplesamlphp_auth_saml_attributes
+ * @param array $attributes
  *   User's Attributes from the simplesaml response.
  * @param string $auth_field
  *   A field name.
- *
  */
- function stanford_ssp_saml_ext_user_alter(&$ext_user, $attributes, $auth_field) {
+function stanford_ssp_saml_ext_user_alter(&$ext_user, array $attributes, $auth_field) {
 
-   // If a user has already been found we don't need to provide any extra work.
-   if ($ext_user) {
-     return;
-   }
+  // If a user has already been found we don't need to provide any extra work.
+  if ($ext_user) {
+    return;
+  }
 
-   // If still no user try sunet id.
-   if (!$ext_user) {
-     $sunet = $attributes["uid"];
-     if (is_array($sunet)) {
-       $sunet = array_pop($sunet);
-     }
-     $ext_user = stanford_ssp_user_load_by_sunetid($sunet);
-   }
-
- }
+  // If still no user try sunet id.
+  if (!$ext_user) {
+    $sunet = $attributes["uid"];
+    if (is_array($sunet)) {
+      $sunet = array_pop($sunet);
+    }
+    $ext_user = stanford_ssp_user_load_by_sunetid($sunet);
+  }
+}
 
 /**
  * Loads a user by sunet id.
@@ -314,10 +313,10 @@ function stanford_ssp_page_build(&$page) {
  */
 function stanford_ssp_user_load_by_sunetid($sunetid) {
   $uid = db_select("stanford_ssp_sunetid", "sss")
-        ->fields("sss", array("uid"))
-        ->condition("sunet", check_plain($sunetid))
-        ->execute()
-        ->fetchField();
+    ->fields("sss", array("uid"))
+    ->condition("sunet", check_plain($sunetid))
+    ->execute()
+    ->fetchField();
 
   if (is_numeric($uid)) {
     return user_load($uid);
@@ -329,8 +328,8 @@ function stanford_ssp_user_load_by_sunetid($sunetid) {
 /**
  * Returns the sunet id of a user by their Drupal uid.
  *
- * @param  int $uid
- *   Drupal user account id
+ * @param int $uid
+ *   Drupal user account id.
  *
  * @return mixed
  *   string if valid account found.
@@ -354,7 +353,8 @@ function stanford_ssp_user_insert(&$edit, $account, $category) {
   // Get the users attributes.
   try {
     $attributes = stanford_simplesamlphp_auth_get_saml_attributes();
-  } catch(Exception $e) {
+  }
+  catch (Exception $e) {
     watchdog('stanford_ssp_user_insert', 'Could not load SAML information', array(), WATCHDOG_DEBUG);
   }
 
@@ -394,7 +394,7 @@ function stanford_ssp_user_delete($account) {
  * @return bool
  *   True if ok. False is not allowed to log in.
  */
-function stanford_ssp_stanford_simplesamlphp_auth_allow_login($attributes) {
+function stanford_ssp_stanford_simplesamlphp_auth_allow_login(array $attributes) {
 
   // Is the user allowed to log in?
   $isok = TRUE;
@@ -427,30 +427,57 @@ function stanford_ssp_stanford_simplesamlphp_auth_allow_login($attributes) {
 
 /**
  * Validates a list of sunets against the user that is trying to log in.
- * @param  [type] $sunets     [description]
- * @param  [type] $attributes [description]
- * @return [type]             [description]
+ *
+ * @param array $sunets
+ *   An array of sunets.
+ * @param array $attributes
+ *   An array of saml attributes.
+ *
+ * @return bool
+ *   True if sunet is in attributes;
  */
-function stanford_ssp_simplesamlphp_auth_allow_login_validate_sunets($sunets, $attributes) {
+function stanford_ssp_simplesamlphp_auth_allow_login_validate_sunets(array $sunets, array $attributes) {
   $sunetid = array_pop($attributes['uid']);
   return in_array($sunetid, $sunets);
 }
 
 /**
- * [stanford_ssp_simplesamlphp_auth_allow_login_validate_groups description]
- * @param  [type] $groups     [description]
- * @param  [type] $attributes [description]
- * @return [type]             [description]
+ * Validates wether a user is in a group.
+ *
+ * @param array $groups
+ *   An array of groups. Both priv and workgroup.
+ * @param array $attributes
+ *   An array of SAML attributes.
+ *
+ * @return bool
+ *   True if there are any matches.
  */
-function stanford_ssp_simplesamlphp_auth_allow_login_validate_groups($groups, $attributes) {
-  $samlgroups = $attributes['eduPersonEntitlement'];
-  return (count(array_intersect($groups, $samlgroups)) > 0);
+function stanford_ssp_simplesamlphp_auth_allow_login_validate_groups(array $groups, array $attributes) {
+
+  // How do we validate the group? Via saml attribute or by the workgroup api?
+  $method = variable_get('stanford_ssp_role_map_source', 'entitlement';)
+  $result = FALSE;
+
+  switch ($method) {
+    case "workgroup":
+      $sunet = array_pop($attributes['uid']);
+      $result = stanford_ssp_validate_workgroup_by_api($sunet, $groups);
+      break;
+
+    default:
+      if (!isset($attributes['eduPersonEntitlement'])) {
+        watchdog('stanford_ssp', 'No eduPersonEntitlement available for workgroup mapping. Ensure you have gotten the appropriate information released from the identity provider.', array(), WATCHDOG_ERROR);
+        return $result;
+      }
+      $samlgroups = $attributes['eduPersonEntitlement'];
+      $result = (count(array_intersect($groups, $samlgroups)) > 0);
+  }
+
+  return $result;
 }
 
 /**
- * Implements simplesamlphp_auth_user_roles_alter()
- * @param  [type] $roles [description]
- * @return [type]        [description]
+ * Implements simplesamlphp_auth_user_roles_alter().
  */
 function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
   $saml = stanford_simplesamlphp_auth_get_saml_info();
@@ -492,7 +519,7 @@ function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
     // Unline implesamlphp_auths re-assign roles option this will only add/grant
     // additional roles to the user.
     case 'grant':
-      $new_roles= $user->roles + $values;
+      $new_roles = $user->roles + $values;
       $userinfo = array('roles' => $new_roles);
       break;
   }
@@ -513,6 +540,7 @@ function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
 
 /**
  * Maps the affiliations to the user roles.
+ *
  * @param object $user
  *   The user to check the attributes on. Probably should be the currently
  *   logged in user as the attributes come from that user anyhow.
@@ -529,8 +557,6 @@ function stanford_ssp_auth_role_map_person_affiliation(&$user) {
     '/staff/i' => 'Stanford Staff',
     '/postdoc/i' => 'Stanford Student',
     '/student/i' => 'Stanford Student',
-    // '/member/' => 'SSO User',
-    // '/affiliate/' => 'SSO User',
   );
 
   // Loop through the expressions looking for matches in the maps array.
@@ -590,6 +616,7 @@ function stanford_ssp_form_user_profile_form_alter(&$form, &$form_state) {
   }
 
 }
+
 /**
  * Implements hook_form_FORMID_alter().
  *
@@ -650,6 +677,7 @@ function stanford_ssp_form_user_login_alter(&$form, &$form_state) {
   }
 
 }
+
 /**
  * Implements hook form alter.
  * @param  [type] $form       [description]
@@ -779,7 +807,6 @@ function stanford_ssp_import_webauth_settings() {
   // webauth_default_role
   // 1. Add the SSO Role to everyone that already exists as a webauth user.
   // X (maybe). Change the authmap key to email from sunetid.
-
   $authmaps = db_select("authmap")
     ->fields("authmap", array("authname", "uid"))
     ->condition("module", "stanford_simplesamlphp_auth")
@@ -820,10 +847,13 @@ function stanford_ssp_import_webauth_settings() {
 }
 
 /**
+ * Get the mappings from the webauth table.
+ *
  * Query the `webauth_roles` table to get an array of Role IDs and the workgroup
  * they are mapped to.
  *
- * @return array An array of objects that each contain an rid and a workgroup.
+ * @return array
+ *   An array of objects that each contain an rid and a workgroup.
  */
 function stanford_ssp_get_webauth_role_mappings() {
   $query = db_select("webauth_roles", "wr")
@@ -857,4 +887,69 @@ function stanford_ssp_convert_webauth_role_mappings() {
   }
   $new_rolepop = implode('|', $roles);
   variable_set('stanford_simplesamlphp_auth_rolepopulation', $new_rolepop);
+}
+
+/**
+ * Validate a sunet id against a workgroups through the API.
+ *
+ * @param string $sunet
+ *   A sunet id.
+ * @param array $groups
+ *   The groups to validate against.
+ *
+ * @return bool
+ *   True if in at least one of the groups.
+ */
+function stanford_ssp_validate_workgroup_by_api($sunet, array $groups) {
+
+  foreach ($groups as $group) {
+    $members = stanford_ssp_get_workgroup_members_by_api($group);
+    if (in_array($sunet, $members)) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+
+/**
+ * [stanford_ssp_get_workgroup_members_by_api description]
+ * @param  [type] $group [description]
+ * @return [type]        [description]
+ */
+function stanford_ssp_get_workgroup_members_by_api($group) {
+  $endpoint = variable_get('stanford_ssp_workgroup_api_endpoint', 'https://workgroupsvc.stanford.edu/v1/workgroups/');
+  
+}
+
+
+/**
+ * [stanford_ssp_sample_workgroup_response description]
+ * @return [type] [description]
+ */
+function stanford_ssp_sample_workgroup_response() {
+  $response = <<<EOD
+<?xml version="1.0" encoding="UTF-8"?>
+<workgroup>
+    <description>Test workgroup</description>
+    <filter>FACULTY_STAFF_STUDENT</filter>
+    <visibility>PRIVATE</visibility>
+    <reusable>TRUE</reusable>
+    <privgroup>TRUE</privgroup>
+    <members>
+        <member name="user1" url="https://workgroupsvc.stanford.edu/v1/users/user1"/>
+        <member name="user2" url="https://workgroupsvc.stanford.edu/v1/users/user2"/>
+        <workgroup name="workgroup:mais" url="https://workgroupsvc.stanford.edu/v1/workgroups/workgroup:mais"/>
+        <workgroup name="workgroup:mais-dev" url="https://workgroupsvc.stanford.edu/v1/workgroups/workgroup:mais-dev"/>
+    </members>
+    <administrators>
+        <member name="user3" url="https://workgroupsvc.stanford.edu/v1/users/user3"/>
+        <member name="user4" url="https://workgroupsvc.stanford.edu/v1/users/user4"/>
+        <workgroup name="mais-staff" url="https://workgroupsvc.stanford.edu/v1/workgroups/mais-staff"/>
+    </administrators>
+</workgroup>
+EOD;
+
+  exit($response);
 }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -28,12 +28,14 @@ function stanford_ssp_menu() {
     'title' => "Workgroup XML sample response",
     'description' => "Workgroup data test.",
     'page callback' => 'stanford_ssp_sample_workgroup_response',
+    // Just a test page. Nothing doing here.
     'access callback' => TRUE,
   );
 
   $items['sso/test-test'] = array(
     'title' => 'title title',
     'page callback' => 'stanford_ssp_get_workgroup_members_by_api',
+    // Just a test page. Nothing doing here.
     'access callback' => TRUE,
   );
 
@@ -538,10 +540,6 @@ function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
 
   // Save the new roles.
   $user = user_save($user, $userinfo);
-
-  // We want to map eduPersonAffiliation to roles.
-  // stanford_ssp_auth_role_map_person_affiliation($user);
-
 }
 
 /**
@@ -627,11 +625,6 @@ function stanford_ssp_form_user_profile_form_alter(array &$form, array &$form_st
 
 /**
  * Implements hook_form_FORMID_alter().
- *
- * @param array $form
- *   The form array.
- * @param array &$form_state
- *   The form state array.
  */
 function stanford_ssp_form_user_login_alter(array &$form, array &$form_state) {
 
@@ -688,12 +681,7 @@ function stanford_ssp_form_user_login_alter(array &$form, array &$form_state) {
 }
 
 /**
- * Implements hook form alter.
- *
- * @param array $form
- *   The form array.
- * @param array &$form_state
- *   The form state array.
+ * Implements hook_form_alter().
  */
 function stanford_ssp_form_user_pass_alter(array &$form, array &$form_state) {
   $form["#validate"][] = "stanford_ssp_form_user_pass_alter_validate";

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -681,7 +681,7 @@ function stanford_ssp_form_user_login_alter(array &$form, array &$form_state) {
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_FORM_ID_alter().
  */
 function stanford_ssp_form_user_pass_alter(array &$form, array &$form_state) {
   $form["#validate"][] = "stanford_ssp_form_user_pass_alter_validate";
@@ -950,8 +950,8 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
 
   $ch = curl_init();
   curl_setopt($ch, CURLOPT_URL, $endpoint);
-  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
   curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
   curl_setopt($ch, CURLOPT_TIMEOUT, 5);
   curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
@@ -964,7 +964,7 @@ function stanford_ssp_get_workgroup_members_by_api($group) {
   $errmsg = curl_error($ch);
   curl_close($ch);
 
-  if (empty($response) || ($err == 0 && !empty($errmsg) )) {
+  if (empty($response) || ($err == 0 && !empty($errmsg))) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
     return array();
   }
@@ -1020,19 +1020,19 @@ function stanford_ssp_sample_workgroup_response() {
     <reusable>TRUE</reusable>
     <privgroup>TRUE</privgroup>
     <members>
-        <member name="user1" url="https://workgroupsvc.stanford.edu/v1/users/user1"/>
-        <member name="user2" url="https://workgroupsvc.stanford.edu/v1/users/user2"/>
+        <member id="sunet1" name="user1" url="https://workgroupsvc.stanford.edu/v1/users/user1"/>
+        <member id="sunet2" name="user2" url="https://workgroupsvc.stanford.edu/v1/users/user2"/>
         <workgroup name="workgroup:mais" url="https://workgroupsvc.stanford.edu/v1/workgroups/workgroup:mais"/>
         <workgroup name="workgroup:mais-dev" url="https://workgroupsvc.stanford.edu/v1/workgroups/workgroup:mais-dev"/>
     </members>
     <administrators>
-        <member name="user3" url="https://workgroupsvc.stanford.edu/v1/users/user3"/>
-        <member name="user4" url="https://workgroupsvc.stanford.edu/v1/users/user4"/>
+        <member id="sunet3" name="user3" url="https://workgroupsvc.stanford.edu/v1/users/user3"/>
+        <member id="sunet4" name="user4" url="https://workgroupsvc.stanford.edu/v1/users/user4"/>
         <workgroup name="mais-staff" url="https://workgroupsvc.stanford.edu/v1/workgroups/mais-staff"/>
     </administrators>
 </workgroup>
 EOD;
 
   print($response);
-  exit();
+  drupal_exit();
 }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -540,7 +540,7 @@ function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
   $user = user_save($user, $userinfo);
 
   // We want to map eduPersonAffiliation to roles.
-  stanford_ssp_auth_role_map_person_affiliation($user);
+  // stanford_ssp_auth_role_map_person_affiliation($user);
 
 }
 
@@ -887,7 +887,7 @@ function stanford_ssp_convert_webauth_role_mappings() {
   // Update stanford_ssp_map_entitlement_to_role() to use this explode/implode,
   // and then use that function here.
   $webauth_roles = stanford_ssp_get_webauth_role_mappings();
-  $rolepop = variable_get('stanford_simplesamlphp_auth_rolepopulation', NULL);
+  $rolepop = variable_get('stanford_simplesamlphp_auth_rolepopulation', '');
   $roles = array();
   if (!is_null($rolepop)) {
     $roles = explode('|', $rolepop);

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -704,13 +704,13 @@ function stanford_ssp_form_user_pass_alter_validate(array $form, array $form_sta
 /**
  * Formats workgroup entitlment.
  *
- * Eg: anchorage:humanbiology-admins to anchorage_humanbiology-admins.
+ * E.g.: helpdesk:consultants to helpdesk_consultants.
  *
  * @param string $entitlement
- *   Eg: anchorage:humanbiology-admins.
+ *   E.g.: helpdesk:consultants.
  *
  * @return string
- *   eg: anchorage_humanbiology-admins
+ *   E.g.: helpdesk_consultants
  */
 function stanford_ssp_format_entitlement($entitlement) {
   $format_enabled = variable_get('stanford_ssp_format_entitlements', FALSE);

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -21,14 +21,20 @@ function stanford_ssp_menu() {
   $items['sso/denied-test'] = array(
     'title' => "Always denied",
     'description' => "Authentication endpoint test.",
-    'page callback' => 'stanford_ssp_sample_workgroup_response',
+    'page callback' => 'stanford_ssp_sso_auth',
   );
 
   $items['sso/workgroup-test'] = array(
     'title' => "Workgroup XML sample response",
     'description' => "Workgroup data test.",
-    'page callback' => 'stanford_ssp_sso_auth',
-    'access callback' => FALSE,
+    'page callback' => 'stanford_ssp_sample_workgroup_response',
+    'access callback' => TRUE,
+  );
+
+  $items['sso/test-test'] = array(
+    'title' => 'title title',
+    'page callback' => 'stanford_ssp_get_workgroup_members_by_api',
+    'access callback' => TRUE,
   );
 
   // Configuration Forms
@@ -455,7 +461,7 @@ function stanford_ssp_simplesamlphp_auth_allow_login_validate_sunets(array $sune
 function stanford_ssp_simplesamlphp_auth_allow_login_validate_groups(array $groups, array $attributes) {
 
   // How do we validate the group? Via saml attribute or by the workgroup api?
-  $method = variable_get('stanford_ssp_role_map_source', 'entitlement';)
+  $method = variable_get('stanford_ssp_role_map_source', 'entitlement');
   $result = FALSE;
 
   switch ($method) {
@@ -912,23 +918,74 @@ function stanford_ssp_validate_workgroup_by_api($sunet, array $groups) {
   return FALSE;
 }
 
-
 /**
- * [stanford_ssp_get_workgroup_members_by_api description]
- * @param  [type] $group [description]
- * @return [type]        [description]
+ * Get an array of sunet ids in a workgroup.
+ *
+ * @param string $group
+ *   The workgroup name. eg: `mais:test`.
+ *
+ * @return array
+ *   An array of members for the passed in workgroup.
  */
 function stanford_ssp_get_workgroup_members_by_api($group) {
+
+  // Validate group name. Needs to be in the format 'something:something'.
+  $xp = explode($group, ":");
+  if (count($xp) !== 2) {
+    watchdog('stanford_ssp', 'Invalid workgroup format.', array(), WATCHDOG_ERROR);
+    return array();
+  }
+
+  // Workgroup endpoint. Needs and installed SSL cert to work.
   $endpoint = variable_get('stanford_ssp_workgroup_api_endpoint', 'https://workgroupsvc.stanford.edu/v1/workgroups/');
-  
+  $endpoint .= $group;
+
+  $response = drupal_http_request($endpoint, array('timeout' => 5));
+
+  if ($response->code !== "200") {
+    watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
+    return array();
+  }
+
+  // We have a valid response. Load up the xml and parse out the users.
+  $xml = simplexml_load_string($response->data);
+  $json = json_encode($xml);
+  $values = json_decode($json, TRUE);
+
+  $members = array();
+  foreach ($values['administrators']['member'] as $member) {
+    $members[] = stanford_ssp_get_api_members_from_xml_array($member);
+  }
+
+  foreach ($values['administrators']['member'] as $member) {
+    $members[] = stanford_ssp_get_api_members_from_xml_array($member);
+  }
+
+  return array_unique($members);
 }
 
+/**
+ * Pull out the sunet id of the member from the xml array.
+ *
+ * @param array $member
+ *   Member from api repsonse.
+ *
+ * @return string
+ *   Sunet id.
+ */
+function stanford_ssp_get_api_members_from_xml_array(array $member) {
+  return $member['@attributes']['name'];
+}
 
 /**
  * [stanford_ssp_sample_workgroup_response description]
  * @return [type] [description]
  */
 function stanford_ssp_sample_workgroup_response() {
+
+  // drupal_add_http_header('Content-Disposition', 'attachment; filename="mais:test.xml"');
+  drupal_add_http_header('Content-Type', 'text/xml;charset=UTF-8');
+
   $response = <<<EOD
 <?xml version="1.0" encoding="UTF-8"?>
 <workgroup>
@@ -951,5 +1008,6 @@ function stanford_ssp_sample_workgroup_response() {
 </workgroup>
 EOD;
 
-  exit($response);
+  print($response);
+  exit();
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds workgroup API role evaluation
- Adds ability to toggle between workgroup formats ":" vs "_"

# Needed By (Date)
- End of sprint?

# Urgency
- 6 out of 10?

# Steps to Test

1. On your local, check out the latest of the socorro branch for acsf_cardinald7 and this branch
2. Ensure you have a jsv or other jumpstart site with the `acsf` itasks build so that stanford_ssp module is enabled
3. Log in as an administrator and navigate to /admin/config/stanford/stanford_ssp/role-mappings
4. Add an administrator workgroup mapping for itservices:webservices
5. Select workgroup api radio as the validation source
6. Enter the server path to the cert `buws-cardinald7-test.cert`
7. Enter the server path to the key `wkgrp-test.key`
8. Manually set the workgroup api to the UAT server via drush `drush vset stanford_ssp_workgroup_api_endpoint https://workgroupsvc-uat.stanford.edu/v1/workgroups/`
9. Remove all of your users roles through the UI
10. Log out of your user
11. Log back in via `sso/login`
12. Validate you have new roles

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)