### PR TITLE
SITES-492: Notify user on drush ssp-au command.

### DIFF
--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -756,7 +756,6 @@ function stanford_ssp_mail($key, &$message, $params) {
   $language = $message['language'];
   $langcode = isset($language->language) ? $language->language : NULL;
   $subject = t('An administrator created an account for you on the [site:name] website', array(), array('langcode' => $langcode));
-  // TODO: Figure out why this wraps.
   $body = t("[user:name],
 
 An account has been created for you on the [site:name] website. You may now log in with your SUNetID by clicking this link or copying and pasting it to your browser:

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -762,7 +762,7 @@ An account has been created for you on the [site:name] website. You may now log 
 
 [site:url]sso/login?goto=user
 
---  [site:name] team", array(), array('langcode' => $langcode));
+--  [site:name] web team", array(), array('langcode' => $langcode));
 
   $subject = token_replace($subject, $params,
     array(

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -758,14 +758,28 @@ function stanford_ssp_mail($key, &$message, $params) {
   $subject = t('An administrator created an account for you at [site:name]', array(), array('langcode' => $langcode));
   $body = t("[user:name],
 
-An account has been created for you at [site:name]. You may now log in with Stanford Web Login by clicking this link or copying and pasting it to your browser:
+An account has been created for you at [site:name]. You may now log in with your SUNetID by clicking this link or copying and pasting it to your browser:
 
-[site:url]sso/login?goto=admin/content
+[site:url]sso/login
 
 --  [site:name] team", array(), array('langcode' => $langcode));
 
-  $subject = token_replace($subject, $params, array('language' => $language, 'callback' => 'user_mail_tokens', 'sanitize' => FALSE, 'clear' => TRUE));
-  $body = token_replace($body, $params, array('language' => $language, 'callback' => 'user_mail_tokens', 'sanitize' => FALSE, 'clear' => TRUE));
+  $subject = token_replace($subject, $params,
+    array(
+      'language' => $language,
+      'callback' => 'user_mail_tokens',
+      'sanitize' => FALSE,
+      'clear' => TRUE,
+    )
+  );
+  $body = token_replace($body, $params,
+    array(
+      'language' => $language,
+      'callback' => 'user_mail_tokens',
+      'sanitize' => FALSE,
+      'clear' => TRUE
+    )
+  );
 
   $message['subject'] = $subject;
   $message['body'][] = $body;

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -777,7 +777,7 @@ An account has been created for you at [site:name]. You may now log in with your
       'language' => $language,
       'callback' => 'user_mail_tokens',
       'sanitize' => FALSE,
-      'clear' => TRUE
+      'clear' => TRUE,
     )
   );
 

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -762,7 +762,9 @@ An account has been created for you on the [site:name] website. You may now log 
 
 [site:url]sso/login?goto=user
 
---  [site:name] web team", array(), array('langcode' => $langcode));
+Sincerely,
+
+[site:name] web team", array(), array('langcode' => $langcode));
 
   $subject = token_replace($subject, $params,
     array(

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -755,12 +755,12 @@ function stanford_ssp_mail($key, &$message, $params) {
 
   $language = $message['language'];
   $langcode = isset($language->language) ? $language->language : NULL;
-  $subject = t('An administrator created an account for you at [site:name]', array(), array('langcode' => $langcode));
+  $subject = t('An administrator created an account for you on the [site:name] website', array(), array('langcode' => $langcode));
   $body = t("[user:name],
 
-An account has been created for you at [site:name]. You may now log in with your SUNetID by clicking this link or copying and pasting it to your browser:
+An account has been created for you on the [site:name] website. You may now log in with your SUNetID by clicking this link or copying and pasting it to your browser:
 
-[site:url]sso/login
+[site:url]sso/login?goto=user
 
 --  [site:name] team", array(), array('langcode' => $langcode));
 

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -756,6 +756,7 @@ function stanford_ssp_mail($key, &$message, $params) {
   $language = $message['language'];
   $langcode = isset($language->language) ? $language->language : NULL;
   $subject = t('An administrator created an account for you on the [site:name] website', array(), array('langcode' => $langcode));
+  // TODO: Figure out why this wraps.
   $body = t("[user:name],
 
 An account has been created for you on the [site:name] website. You may now log in with your SUNetID by clicking this link or copying and pasting it to your browser:

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -730,7 +730,8 @@ function stanford_ssp_add_sso_user_submit(array &$form, array &$form_state) {
 
   // Was the notify checkbox checked?
   if ($form_state["values"]["notify"] && $account) {
-    _user_mail_notify('status_activated', $account);
+    global $language;
+    drupal_mail('stanford_ssp', 'new_account', $account->mail, $language, ['account' => $account, 'user' => $account]);
     drupal_set_message(t("Email sent to user"), "status");
   }
 
@@ -741,6 +742,34 @@ function stanford_ssp_add_sso_user_submit(array &$form, array &$form_state) {
   );
 
   drupal_write_record("stanford_ssp_sunetid", $record);
+}
+
+/**
+ * Implements hook_mail().
+ */
+function stanford_ssp_mail($key, &$message, $params) {
+
+  if ($key !== "new_account") {
+    return;
+  }
+
+  $language = $message['language'];
+  $langcode = isset($language->language) ? $language->language : NULL;
+  $subject = t('An administrator created an account for you at [site:name]', array(), array('langcode' => $langcode));
+  $body = t("[user:name],
+
+An account has been created for you at [site:name]. You may now log in with Stanford Web Login by clicking this link or copying and pasting it to your browser:
+
+[site:url]sso/login?goto=admin/content
+
+--  [site:name] team", array(), array('langcode' => $langcode));
+
+  $subject = token_replace($subject, $params, array('language' => $language, 'callback' => 'user_mail_tokens', 'sanitize' => FALSE, 'clear' => TRUE));
+  $body = token_replace($body, $params, array('language' => $language, 'callback' => 'user_mail_tokens', 'sanitize' => FALSE, 'clear' => TRUE));
+
+  $message['subject'] = $subject;
+  $message['body'][] = $body;
+
 }
 
 /**

--- a/stanford_ssp.drush.inc
+++ b/stanford_ssp.drush.inc
@@ -32,7 +32,7 @@ function stanford_ssp_drush_command() {
       'name' => 'The user\'s name',
       'email' => 'The user\'s email',
       'roles' => 'Comma separated list of role names',
-      'notify' => 'Send email to the user (boolean)?',
+      'notify-user' => 'Send email to the user (boolean)?',
     ),
     'aliases' => array('ssp-au'),
   );
@@ -118,7 +118,7 @@ function drush_stanford_ssp_saml_add_user($sunet) {
   }
 
   // @todo: Make this an option.
-  $notify = drush_get_option("notify");
+  $notify = drush_get_option("notify-user");
   if (!empty($notify) && ($notify == "true" || (int) $notify == 1)) {
     $form_state["values"]["notify"] = TRUE;
   }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -378,7 +378,8 @@ function stanford_ssp_user_insert(&$edit, $account, $category) {
   }
 
   // If the new account and the current user don't have matching emails then
-  // the account must have been created by a form instead of through login.
+  // the account must have been created by a form or drush instead of through
+  // the user actually doing a login themselves.
   if (isset($attributes['email'][0]) && ($attributes['email'][0] !== $account->init)) {
     return;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Turns out the `--notify` option is reserved for drush
- Changed command option to `--notify-user` 
- SAML warning in watchdog is just debugging messaging and nothing to worry about.

# Needed By (Date)
- Whenever

# Urgency
- 1-10? 1

# Steps to Test

1.  Check out this branch
2. Create a new user using `drush ssp-au sunetid --notify-user=true`

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)