### PR TITLE
Grant SUNet User role conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ You may also modify the default behaviour of the Local Drupal accounts and preve
 
 Use this form to add user accounts that may authenticate with SAML. This is useful for adding users and granting them roles prior to their first log in.
 
+Migrating from the WebAuth Module for Drupal (WMD) to Stanford SimpleSAMLphp (Stanford SSP)
+---
+There is a drush command (`drush stanford-ssp-migrate-wmd` or `drush sspwmd`) to help migrate from WMD to Stanford SimpleSAMLphp.
+
+That command:
+1. Enables the `stanford_ssp_block` module (to place the "SUNetID Login" block)
+2. Transfers permissions from the "SUNet User" role to the "SSO User" role
+3. If set, sets the destination for redirecting the user upon successful login
+4. If WMD allowed local Drupal logins, configures Stanford SSP similarly
+5. If the WMD login link text has been customized, sets that link text
+6. If WMD has restrictions on which users or workgroups can log in, sets those options similarly in Stanford SSP
+7. Updates the `authmap` table so that existing WMD users can log in with Stanford SSP
+8. Adds the "SSO User" role to all existing WMD users
+9. Converts WMD workgroup role mappings to Stanford SSP equivalents
+10. Configures Stanford SSP so that users logging in with this module automatically get the "SUNet User" role
+11. Disables and uninstalls WMD
+
+#### The "SUNet User" role
+By default, users logging in with Stanford SimpleSAMLphp do **not** get the "SUNet User" role. If you are upgrading a site from WMD to Stanford SSP, and you want users who log in to get the "SUNet User" role, you **must** run `drush sspwmd`. 
+
 Troubleshooting
 ---
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -872,7 +872,8 @@ function stanford_ssp_import_webauth_settings() {
   variable_set('stanford_ssp_prevent_cache', FALSE);
   variable_set('stanford_ssp_show_sso_login', TRUE);
   // Grant all the "SUNet User" role to all users who log in with stanford_ssp.
-  // We are assuming that we want this if we are upgrading from WMD to stanford_ssp.
+  // We are assuming that we want this
+  // if we are upgrading from WMD to stanford_ssp.
   variable_set('stanford_ssp_grant_sunet_user_role', TRUE);
 
   // Convert our WMD role mappings to Stanford SSP.

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -550,6 +550,12 @@ function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
     $userinfo['roles'][$sso_user_role->rid] = $sso_user_role->name;
   }
 
+  // Always add the SUNet User role if it exists.
+    $sunet_user_role = user_role_load_by_name("SUNet User");
+    if ($sunet_user_role) {
+      $userinfo['roles'][$sunet_user_role->rid] = $sunet_user_role->name;
+  }
+
   // Save the new roles.
   $user = user_save($user, $userinfo);
 }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -550,10 +550,13 @@ function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
     $userinfo['roles'][$sso_user_role->rid] = $sso_user_role->name;
   }
 
-  // Always add the SUNet User role if it exists.
-  $sunet_user_role = user_role_load_by_name("SUNet User");
-  if ($sunet_user_role) {
-    $userinfo['roles'][$sunet_user_role->rid] = $sunet_user_role->name;
+  $add_sunet_user_role = variable_get('stanford_ssp_grant_sunet_user_role', FALSE);
+  if ($add_sunet_user_role) {
+    // Always add the SUNet User role if it exists.
+    $sunet_user_role = user_role_load_by_name("SUNet User");
+    if ($sunet_user_role) {
+      $userinfo['roles'][$sunet_user_role->rid] = $sunet_user_role->name;
+    }
   }
 
   // Save the new roles.
@@ -868,6 +871,9 @@ function stanford_ssp_import_webauth_settings() {
   variable_set('stanford_simplesamlphp_auth_autoenablesaml', TRUE);
   variable_set('stanford_ssp_prevent_cache', FALSE);
   variable_set('stanford_ssp_show_sso_login', TRUE);
+  // Grant all the "SUNet User" role to all users who log in with stanford_ssp.
+  // We are assuming that we want this if we are upgrading from WMD to stanford_ssp.
+  variable_set('stanford_ssp_grant_sunet_user_role', TRUE);
 
   // Convert our WMD role mappings to Stanford SSP.
   stanford_ssp_convert_webauth_role_mappings();

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -551,9 +551,9 @@ function stanford_ssp_stanford_simplesamlphp_auth_user_roles_alter($user) {
   }
 
   // Always add the SUNet User role if it exists.
-    $sunet_user_role = user_role_load_by_name("SUNet User");
-    if ($sunet_user_role) {
-      $userinfo['roles'][$sunet_user_role->rid] = $sunet_user_role->name;
+  $sunet_user_role = user_role_load_by_name("SUNet User");
+  if ($sunet_user_role) {
+    $userinfo['roles'][$sunet_user_role->rid] = $sunet_user_role->name;
   }
 
   // Save the new roles.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Provide a migration path where we grant the "SUNet User" role if we are migrating from WMD
- Document `drush sspwmd`

# Needed By (Date)
- When you can get to it

# Criticality
- How critical is this PR on a 1-10 scale? 2/10


# Steps to Test

1. Grab a DB dump from a site with WMD where you do **not** have a user account
2. Install `stanford_ssp-7.x-2.x`
3. Log in
4. See that you do **not** get the "SUNet User" role
5. Restore from DB dump
6. Check out this branch
7. Log in
8. See that you do **not** get the "SUNet User" role
9. Restore from DB dump
10. Check out this branch
11. Run `drush sspwmd`
12. Log in
13. See that you **do** get the "SUNet User" role
14. Review the updated README for Migrating from WMD and check for inaccuracies or blatant lies


# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules? ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-704
- Other PRs: #41 
- Anyone who should be notified? ( @wilsonww )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)