### PR TITLE
SITES-676: Prevent duplicate values when creating new user.

### DIFF
--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -364,8 +364,7 @@ function stanford_ssp_user_insert(&$edit, $account, $category) {
   catch (Exception $e) {
     watchdog('stanford_ssp_user_insert', 'Could not load SAML information', array(), WATCHDOG_DEBUG);
   }
-
-
+  
   // If the new account and the current user don't have matching emails then
   // the account must have been created by a form or drush instead of through
   // the user actually doing a login themselves.

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -365,16 +365,11 @@ function stanford_ssp_user_insert(&$edit, $account, $category) {
     watchdog('stanford_ssp_user_insert', 'Could not load SAML information', array(), WATCHDOG_DEBUG);
   }
 
-  // If the new account and the current user don't have matching emails then
-  // the account must have been created by a form or drush instead of through
-  // the user actually doing a login themselves.
-  if (isset($attributes['email'][0]) && ($attributes['email'][0] !== $account->init)) {
-    return;
-  }
-
-  // Different SPs have different values for this...
-  if (isset($attributes['mail'][0]) && ($attributes['mail'][0] !== $account->init)) {
-    return;
+  // Some SPs and users do not provide mail or email attributes. Use something
+  // else to try and validate that the created user is not the current user. The
+  // best thing we can try to use is the sunet id.
+  if (isset($attributes['uid'][0]) && ($attributes['uid'][0] !== str_replace("@stanford", "", $account->init))) {
+    return FALSE;
   }
 
   // Act on the current user.

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -364,7 +364,7 @@ function stanford_ssp_user_insert(&$edit, $account, $category) {
   catch (Exception $e) {
     watchdog('stanford_ssp_user_insert', 'Could not load SAML information', array(), WATCHDOG_DEBUG);
   }
-  
+
   // If the new account and the current user don't have matching emails then
   // the account must have been created by a form or drush instead of through
   // the user actually doing a login themselves.

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -365,10 +365,16 @@ function stanford_ssp_user_insert(&$edit, $account, $category) {
     watchdog('stanford_ssp_user_insert', 'Could not load SAML information', array(), WATCHDOG_DEBUG);
   }
 
+
   // If the new account and the current user don't have matching emails then
   // the account must have been created by a form or drush instead of through
   // the user actually doing a login themselves.
   if (isset($attributes['email'][0]) && ($attributes['email'][0] !== $account->init)) {
+    return;
+  }
+
+  // Different SPs have different values for this...
+  if (isset($attributes['mail'][0]) && ($attributes['mail'][0] !== $account->init)) {
     return;
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes issue with creating a new user.

# Needed By (Date)
- Soon as you can

# Urgency
- 7/10

# Steps to Test

1. Spin up a site on the 7.x-2.x branch of this module
2. Log in and try to create a local user and a SSO user. Get error on both.
3. Check out this branch.
4. Repeat step 2 but with success

# Associated Issues and/or People
- SITES-676

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)