### PR TITLE
SITES-924: access sso/login in maintenance mode

### DIFF
--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -144,6 +144,17 @@ function stanford_ssp_access_login_page() {
 }
 
 /**
+ * Implement hook_menu_site_status_alter().
+ *
+ * Allow access to log in when site is in maintenance mode.
+ */
+function stanford_ssp_menu_site_status_alter(&$menu_site_status, $path) {
+  if ($menu_site_status == MENU_SITE_OFFLINE && $path == 'sso/login') {
+    $menu_site_status = MENU_SITE_ONLINE;
+  }
+}
+
+/**
  * Redirect saml_login to sso/login.
  */
 function stanford_ssp_redirect() {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow users to log in when site is in maintenance mode

# Needed By (Date)
- The sooner you merge this, the sooner I get to stop dealing with SNOW tickets from a specific user who keeps locking himself out of his site

# Criticality
- How critical is this PR on a 1-10 scale? 3/10

# Steps to Test

1. Create an SSO account for yourself that has a privileged role, with the permission to access the site in maintenance mode
2. Check out 7.x-2.x
3. Put the site in maintenance mode
4. Log out
5. Try to log in at `sso/login`
6. Fail
7. Check out this branch
8. Try to log in at `sso/login`
9. Succeed

# Affected Projects or Products
- SAML authentication

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-924

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)