### PR TITLE
SITES-892: Webauth upgrade path fix for block placement 

### DIFF
--- a/modules/stanford_saml_block/stanford_saml_block.context.inc
+++ b/modules/stanford_saml_block/stanford_saml_block.context.inc
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * stanford_webauth_block.context.inc
+ * stanford_saml_block.context.inc
  */
 
 /**

--- a/modules/stanford_saml_block/stanford_saml_block.context.inc
+++ b/modules/stanford_saml_block/stanford_saml_block.context.inc
@@ -11,7 +11,7 @@ function stanford_saml_block_context_default_contexts() {
   $export = array();
 
   $context = new stdClass();
-  $context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
+  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
   $context->api_version = 3;
   $context->name = 'stanford_simplesamlphp_login';
   $context->description = 'Simplesamlphp Login Block';

--- a/modules/stanford_saml_block/stanford_saml_block.context.inc
+++ b/modules/stanford_saml_block/stanford_saml_block.context.inc
@@ -11,7 +11,7 @@ function stanford_saml_block_context_default_contexts() {
   $export = array();
 
   $context = new stdClass();
-  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+  $context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
   $context->api_version = 3;
   $context->name = 'stanford_simplesamlphp_login';
   $context->description = 'Simplesamlphp Login Block';

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -772,6 +772,15 @@ function stanford_ssp_import_webauth_settings() {
   if (!module_exists("stanford_saml_block")) {
     module_enable(array("stanford_saml_block"));
     drush_log("Enabled stanford_saml_block", "success");
+
+    // Update the webauth block settings to be saml block settings.
+    db_update("block")
+      ->fields([
+        'module' => 'stanford_saml_block',
+        'delta' => 'stanford_saml_block_login_block',
+      ])
+      ->condition('module', 'webauth')
+      ->execute();
   }
 
   $sso_role = user_role_load_by_name('SSO User');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Swap out stanford_saml_block for webauth block and disable the context by default.
- By replacing the webauth block for the saml block in the DB table we will get everywhere the webauth block was placed using core blocks.
- Disables a not-so-good context by default. Never liked that placement anyhow.

# Needed By (Date)
- ?

# Urgency
- Lower

# Steps to Test

1. Check out this branch
2. (on local) sync people site `sheamck`'s database down
3. Run `drush rr`
4. Run `drush updb -y`
5. Run `drush en stanford_ssp -y`
6. Run `drush sspwmd -y`
8. Clear caches and view the home page. SAML block should be in left sidebar. 

# Affected Projects or Products
- Migration

# Associated Issues and/or People
- SITES-892

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)