### PR TITLE
SITES-784: Better error handling. Skip stanford:* type workgroups.

### DIFF
--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.inc
@@ -161,6 +161,9 @@ function stanford_simplesamlphp_auth_user_register() {
   // Add to the authmap table.
   user_set_authmaps($account, array("authname_stanford_simplesamlphp_auth" => $authname));
 
+  // Always do type evaluation.
+  stanford_ssp_auth_role_map_person_affiliation($account);
+
   // Allow others to alter the default roles of the new user.
   drupal_alter('stanford_simplesamlphp_auth_user_roles', $account);
 

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -493,6 +493,12 @@ function stanford_simplesamlphp_auth_rolepopulation($rolemap) {
   $rolerules = explode('|', $rolemap);
   foreach ($rolerules as $rolerule) {
 
+    // Something is not right here.
+    if (empty($rolerule)) {
+      watchdog('stanford_simplesamlphp_auth', 'Empty role rule. Could not process.', array(), WATCHDOG_NOTICE);
+      continue;
+    }
+
     $roleruledecompose = explode(':', $rolerule, 2);
     $roleid = $roleruledecompose[0];
     $roleruleevaluations = explode(';', $roleruledecompose[1]);

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -428,7 +428,7 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
 
       // Something went wrong.
       if (empty($rule)) {
-        drupal_set_message('Empty rule string. Please remove it below.', 'error');
+        drupal_set_message(t('Empty rule string. Please remove it below.'), 'error');
         watchdog('stanford_ssp', 'Empty rule string. Please navigate to !link and delete it.', array('!link' => l(t('role mappings'), 'admin/config/stanford/stanford_ssp/role-mappings')), WATCHDOG_ERROR);
         $row = [
           "<span style=\"color:red\">Broken or missing rule.</span>",

--- a/stanford_ssp.admin.inc
+++ b/stanford_ssp.admin.inc
@@ -426,6 +426,19 @@ function stanford_ssp_role_mappings_form(array $form, array &$form_state) {
         '#value' => $index,
       );
 
+      // Something went wrong.
+      if (empty($rule)) {
+        drupal_set_message('Empty rule string. Please remove it below.', 'error');
+        watchdog('stanford_ssp', 'Empty rule string. Please navigate to !link and delete it.', array('!link' => l(t('role mappings'), 'admin/config/stanford/stanford_ssp/role-mappings')), WATCHDOG_ERROR);
+        $row = [
+          "<span style=\"color:red\">Broken or missing rule.</span>",
+          "<span style=\"color:red\">Broken Rule. Remove me.</span>",
+          drupal_render($form[$button_id]),
+        ];
+        $table[] = $row;
+        continue;
+      }
+
       // $rule = rid:expression.
       $bits = explode(':', $rule, 2);
       $role = user_role_load($bits[0]);

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -1051,21 +1051,23 @@ function stanford_ssp_fetch_from_workgroup_api($group = "") {
   $curl_info = curl_getinfo($ch);
   curl_close($ch);
 
-  // If the workgroup is not found, and is not a stanford stem, then the workgroup is invalid.
+  // If the workgroup is not found, and is not a stanford stem,
+  // then the workgroup is invalid.
   if ($curl_info['http_code'] == 404 && strpos($group, "stanford:") !== 0) {
     watchdog('stanford_ssp', 'Workgroup %group not found. <code>!code</code>', ["!code" => serialize($curl_info), '%group' => $group], WATCHDOG_ERROR);
     throw new Exception("Error: Workgroup not found.");
   }
 
-  // If the rest did not reply with a 200 and is not a stem workgroup, there must
-  // have been an error connecting with the API.
+  // If the rest did not reply with a 200 and is not a stem workgroup, there 
+  // must have been an error connecting with the API.
   if ($curl_info['http_code'] !== 200 && strpos($group, "stanford:") !== 0) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api. <code>!code</code>', array("!code" => serialize($curl_info)), WATCHDOG_ERROR);
     throw new Exception("Error fetching workgroup api information.");
   }
 
   // Not allowed. These are special.
-  // Stem workgroups are private and information will not be returned to the requestor.
+  // Stem workgroups are private and information will not be returned to
+  // the requestor.
   if (strpos($group, "stanford:") === 0) {
     throw new Exception("Cannot evaluate stanford:* groups in workgroup api.");
   }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -1062,7 +1062,7 @@ function stanford_ssp_fetch_from_workgroup_api($group = "") {
   }
 
   // Not allowed. These are special.
-  if (strpos($group, "stanford:") == 0) {
+  if (strpos($group, "stanford:") === 0) {
     throw new Exception("Cannot evaluate stanford:* groups in workgroup api.");
   }
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -1051,13 +1051,23 @@ function stanford_ssp_fetch_from_workgroup_api($group = "") {
   $curl_info = curl_getinfo($ch);
   curl_close($ch);
 
-  if ($curl_info['http_code'] !== 200) {
-    watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
+  if ($curl_info['http_code'] == 404 && strpos($group, "stanford:") !== 0) {
+    watchdog('stanford_ssp', 'Workgroup %group not found. <code>!code</code>', ["!code" => serialize($curl_info), '%group' => $group], WATCHDOG_ERROR);
+    throw new Exception("Error: Workgroup not found.");
+  }
+
+  if ($curl_info['http_code'] !== 200 && strpos($group, "stanford:") !== 0) {
+    watchdog('stanford_ssp', 'Failed to fetch workgroup information from api. <code>!code</code>', array("!code" => serialize($curl_info)), WATCHDOG_ERROR);
     throw new Exception("Error fetching workgroup api information.");
   }
 
+  // Not allowed. These are special.
+  if (strpos($group, "stanford:") == 0) {
+    throw new Exception("Cannot evaluate stanford:* groups in workgroup api.");
+  }
+
   if (empty($response) || ($err == 0 && !empty($errmsg))) {
-    watchdog('stanford_ssp', 'Failed to fetch workgroup information from api.', array(), WATCHDOG_ERROR);
+    watchdog('stanford_ssp', '%msg <code>!code</code>', ["!code" => serialize($curl_info), '%msg' => $errmsg], WATCHDOG_ERROR);
     throw new Exception($errmsg);
   }
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -1051,17 +1051,21 @@ function stanford_ssp_fetch_from_workgroup_api($group = "") {
   $curl_info = curl_getinfo($ch);
   curl_close($ch);
 
+  // If the workgroup is not found, and is not a stanford stem, then the workgroup is invalid.
   if ($curl_info['http_code'] == 404 && strpos($group, "stanford:") !== 0) {
     watchdog('stanford_ssp', 'Workgroup %group not found. <code>!code</code>', ["!code" => serialize($curl_info), '%group' => $group], WATCHDOG_ERROR);
     throw new Exception("Error: Workgroup not found.");
   }
 
+  // If the rest did not reply with a 200 and is not a stem workgroup, there must
+  // have been an error connecting with the API.
   if ($curl_info['http_code'] !== 200 && strpos($group, "stanford:") !== 0) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api. <code>!code</code>', array("!code" => serialize($curl_info)), WATCHDOG_ERROR);
     throw new Exception("Error fetching workgroup api information.");
   }
 
   // Not allowed. These are special.
+  // Stem workgroups are private and information will not be returned to the requestor.
   if (strpos($group, "stanford:") === 0) {
     throw new Exception("Cannot evaluate stanford:* groups in workgroup api.");
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Better error handling for bad rules
- Better logging and handling for bad API requests
- Handling for `stanford:*` type workgroup maps. These don't work in the API.
- Force SAML attribute affiliation mapping to handle the `stanford:*` mappings instead. 
- SAML attribute affiliation mapping on user register.

# Needed By (Date)
- For Greg

# Urgency
- Ask Greg

# Steps to Test

1. Copy dennylab to a test environment
2. Log in with sso/login and view logs
3. See PHP errors and warnings 
4. Check out this branch
5. Log out and log back in
6. See no more PHP errors.
7. Delete user account
8. Log out
9. Log back in
10. Validate Affiliation roles have been assigned

# Affected Projects or Products
- All of them
- SOE Migration

# Associated Issues and/or People
- @boznik 
- @jbickar 
- SITES-784

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)