### PR TITLE
SITES-1090: Remove permissions that are still in the DB with no modul…

### DIFF
--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -881,7 +881,10 @@ function stanford_ssp_import_webauth_settings() {
     }
     catch (Exception $e) {
       // Duplicate user detected.
-      echo 'Caught exception: ', $e->getMessage(), "\n";
+      watchdog('stanford_ssp', $e->getMessage(), array(), WATCHDOG_DEBUG);
+      if (function_exists('drush_log')) {
+        drush_log($e->getMessage(), 'warning');
+      }
     }
   }
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -788,7 +788,12 @@ function stanford_ssp_import_webauth_settings() {
   if ($sunet_role) {
     drush_log("Transferring SUNet User permissions to SSO User.", "success");
     $sunet_role_permissions = user_role_permissions(array($sunet_role->rid => $sunet_role->name));
-    user_role_grant_permissions($sso_role->rid, array_keys($sunet_role_permissions[$sunet_role->rid]));
+
+    // Ignore permissions that are still in the DB but not in a module anywhere.
+    $permissions = array_keys(array_shift($sunet_role_permissions));
+    $module_permissions = array_keys(user_permission_get_modules());
+    $valid_permissions = array_intersect($permissions, $module_permissions);
+    user_role_grant_permissions($sso_role->rid, $valid_permissions);
   }
 
   drush_log("Beginning webauth config settings to ssp settings conversion.", "success");
@@ -861,16 +866,21 @@ function stanford_ssp_import_webauth_settings() {
 
   // Loop through the authmaps and add them to the map table.
   while ($entry = $authmaps->fetchObject()) {
-    db_insert("stanford_ssp_sunetid")
-      ->fields([
-        'sunet' => array_shift(explode("@", $entry->authname)),
-        'uid' => $entry->uid,
-      ])
-      ->execute();
+    try {
+      db_insert("stanford_ssp_sunetid")
+        ->fields([
+          'sunet' => array_shift(explode("@", $entry->authname)),
+          'uid' => $entry->uid,
+        ])
+        ->execute();
 
-    // Also grant the new SSO USER role.
-    if (isset($sso_role->rid) && is_numeric($sso_role->rid)) {
-      user_multiple_role_edit(array($entry->uid), 'add_role', $sso_role->rid);
+      // Also grant the new SSO USER role.
+      if (isset($sso_role->rid) && is_numeric($sso_role->rid)) {
+        user_multiple_role_edit(array($entry->uid), 'add_role', $sso_role->rid);
+      }
+    } catch (Exception $e) {
+      // Duplicate user detected.
+      echo 'Caught exception: ',  $e->getMessage(), "\n";
     }
   }
 
@@ -1058,7 +1068,7 @@ function stanford_ssp_fetch_from_workgroup_api($group = "") {
     throw new Exception("Error: Workgroup not found.");
   }
 
-  // If the rest did not reply with a 200 and is not a stem workgroup, there 
+  // If the rest did not reply with a 200 and is not a stem workgroup, there
   // must have been an error connecting with the API.
   if ($curl_info['http_code'] !== 200 && strpos($group, "stanford:") !== 0) {
     watchdog('stanford_ssp', 'Failed to fetch workgroup information from api. <code>!code</code>', array("!code" => serialize($curl_info)), WATCHDOG_ERROR);

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -878,8 +878,8 @@ function stanford_ssp_import_webauth_settings() {
       if (isset($sso_role->rid) && is_numeric($sso_role->rid)) {
         user_multiple_role_edit(array($entry->uid), 'add_role', $sso_role->rid);
       }
-      
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       // Duplicate user detected.
       echo 'Caught exception: ', $e->getMessage(), "\n";
     }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -878,8 +878,8 @@ function stanford_ssp_import_webauth_settings() {
       if (isset($sso_role->rid) && is_numeric($sso_role->rid)) {
         user_multiple_role_edit(array($entry->uid), 'add_role', $sso_role->rid);
       }
+      
     } catch (Exception $e) {
-
       // Duplicate user detected.
       echo 'Caught exception: ', $e->getMessage(), "\n";
     }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -879,8 +879,9 @@ function stanford_ssp_import_webauth_settings() {
         user_multiple_role_edit(array($entry->uid), 'add_role', $sso_role->rid);
       }
     } catch (Exception $e) {
+
       // Duplicate user detected.
-      echo 'Caught exception: ',  $e->getMessage(), "\n";
+      echo 'Caught exception: ', $e->getMessage(), "\n";
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Ignore permissions that are still in the DB but not in a module anywhere.
- Adds try/catch when we loop through the authmaps and add them to the map table for duplicate users.

# Needed By (Date)
- Yesterday

# Urgency
- N/A

# Steps to Test

1. Run `drush @self sspwmd`
2. Cross your fingers.
3. Sing a song.

# Affected Projects or Products
- SITES 2.0

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-1090

## Related PRs

## More Information

## Folks to notify
@sherakama 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)