### PR TITLE
SITES-1109: Workgroups with underscores are invalidated

### DIFF
--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -391,7 +391,7 @@ function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluat
 
   // If formatting is on we need to change it back for the API.
   if (variable_get("stanford_ssp_format_entitlements", FALSE)) {
-    $workgroup = str_replace("_", ":", $workgroup);
+    $workgroup = preg_replace("/_/", ":", $workgroup, 1);
   }
 
   // Unless you were crafty and drush set a special evaluation rule in to the

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -390,7 +390,7 @@ function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluat
   $operation = $roleruleevaluation[1];
 
   // If formatting is on we need to change it back for the API.
-  if (variable_get("stanford_ssp_format_entitlements", TRUE)) {
+  if (variable_get("stanford_ssp_format_entitlements", FALSE)) {
     $workgroup = str_replace("_", ":", $workgroup);
   }
 

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -391,7 +391,12 @@ function stanford_simplesamlphp_auth_api_evaluaterolerule(array $roleruleevaluat
 
   // If formatting is on we need to change it back for the API.
   if (variable_get("stanford_ssp_format_entitlements", FALSE)) {
-    $workgroup = preg_replace("/_/", ":", $workgroup, 1);
+    // Sometimes the formatting gets turned on with legacy information in the DB
+    // This is a safety check to make sure we don't format something that is
+    // already formatted.
+    if (!strpos($workgroup, ":")) {
+      $workgroup = preg_replace("/_/", ":", $workgroup, 1);
+    }
   }
 
   // Unless you were crafty and drush set a special evaluation rule in to the


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix bug where workgroups with underscores in them trigger an "Invalid workgroup format" error

# Needed By (Date)
- When does this need to be merged by? ASAP

# Criticality
- How critical is this PR on a 1-10 scale? 3/10

# Steps to Test

1. Verify that this code is checked out on ACSF `dev`
2. Log in to https://inc00811537workgroupmapping-dev.sites.stanford.edu/sso/login
3. Verify that you get the "Underscore" role

(I already mapped `~jbickar:i_a` to the "Underscore role and added you and me to that workgroup.)

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules? ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-1109

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)