### PR TITLE
HSD8-613 If role_delegation module is enable, limit which roles a user can add in the saml user add form.

### DIFF
--- a/src/Form/AddUserForm.php
+++ b/src/Form/AddUserForm.php
@@ -93,7 +93,7 @@ class AddUserForm extends FormBase {
       '#type' => 'select',
       '#title' => $this->t('Roles'),
       '#description' => $this->t('Add roles to the new user account.'),
-      '#options' => user_role_names(TRUE),
+      '#options' => self::getAvailableRoles(),
       '#multiple' => TRUE,
     ];
 
@@ -107,6 +107,21 @@ class AddUserForm extends FormBase {
       '#value' => $this->t('Add SSO User'),
     ];
     return $form;
+  }
+
+  /**
+   * Get available roles, limited if the role_delegation module is enabled.
+   *
+   * @return array
+   *   Keyed array of role id and role label.
+   */
+  protected static function getAvailableRoles(){
+    if(\Drupal::moduleHandler()->moduleExists('role_delegation')) {
+      /** @var \Drupal\role_delegation\DelegatableRolesInterface $role_delegation */
+      $role_delegation = \Drupal::service('delegatable_roles');
+      return $role_delegation->getAssignableRoles(\Drupal::currentUser());
+    }
+    return user_role_names(TRUE);
   }
 
   /**

--- a/src/Form/AddUserForm.php
+++ b/src/Form/AddUserForm.php
@@ -115,8 +115,8 @@ class AddUserForm extends FormBase {
    * @return array
    *   Keyed array of role id and role label.
    */
-  protected static function getAvailableRoles(){
-    if(\Drupal::moduleHandler()->moduleExists('role_delegation')) {
+  protected static function getAvailableRoles() {
+    if (\Drupal::moduleHandler()->moduleExists('role_delegation')) {
       /** @var \Drupal\role_delegation\DelegatableRolesInterface $role_delegation */
       $role_delegation = \Drupal::service('delegatable_roles');
       return $role_delegation->getAssignableRoles(\Drupal::currentUser());


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When role_delegation is enabled, users should only be able to add roles that they have permission to.
- If role delegation is not enabled, allow all roles.

# Needed By (Date)
- asap

# Urgency
- kinda high. security implications since site managers could add a user with administrator role.

# Steps to Test
1. enable role_delegation and configure for a role
1. go to the user add form as a user with limited role add permissions
1. verify they can not add a user with an administrator role.

# Affected Projects or Products
- Humsci right now, all in the future

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)