### PR TITLE
Decorate service to stop fatal error when mail attribute isnt available

### DIFF
--- a/src/Service/StanfordSSPAuthManager.php
+++ b/src/Service/StanfordSSPAuthManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\stanford_ssp\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\simplesamlphp_auth\Exception\SimplesamlphpAttributeException;
+use Drupal\simplesamlphp_auth\Service\SimplesamlphpAuthManager;
+use SimpleSAML\Auth\Simple;
+use SimpleSAML_Configuration;
+
+class StanfordSSPAuthManager extends SimplesamlphpAuthManager {
+
+  /**
+   * Logger channel service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, LoggerChannelFactoryInterface $logger_factory, Simple $instance = NULL, SimpleSAML_Configuration $config = NULL) {
+    parent::__construct($config_factory, $instance, $config);
+    $this->logger = $logger_factory->get('stanford_ssp');
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * Alter the parent method by preventing a complete break when an attribute is
+   * not available.
+   */
+  public function getAttribute($attribute) {
+    try {
+      return parent::getAttribute($attribute);
+    }
+    catch (SimplesamlphpAttributeException $e) {
+      $this->logger->error($e);
+
+      // If the `mail` attribute isn't available, build one from the uid.
+      if ($attribute == 'mail') {
+        return $this->getAttribute('uid') . '@stanford.edu';
+      }
+    }
+  }
+
+}

--- a/src/Service/StanfordSSPAuthManager.php
+++ b/src/Service/StanfordSSPAuthManager.php
@@ -9,6 +9,11 @@ use Drupal\simplesamlphp_auth\Service\SimplesamlphpAuthManager;
 use SimpleSAML\Auth\Simple;
 use SimpleSAML_Configuration;
 
+/**
+ * Class StanfordSSPAuthManager to decorate auth manager service.
+ *
+ * @package Drupal\stanford_ssp\Service
+ */
 class StanfordSSPAuthManager extends SimplesamlphpAuthManager {
 
   /**
@@ -40,8 +45,9 @@ class StanfordSSPAuthManager extends SimplesamlphpAuthManager {
       $this->logger->error($e);
 
       // If the `mail` attribute isn't available, build one from the uid.
+      // Authname is normally the `uid` attribute which is the SUNetId.
       if ($attribute == 'mail') {
-        return $this->getAttribute('uid') . '@stanford.edu';
+        return $this->getAuthname() . '@stanford.edu';
       }
     }
   }

--- a/stanford_ssp.services.yml
+++ b/stanford_ssp.services.yml
@@ -1,4 +1,9 @@
 services:
+  stanford_ssp.auth_manager:
+    class: Drupal\stanford_ssp\Service\StanfordSSPAuthManager
+    public: false
+    decorates: simplesamlphp_auth.manager
+    arguments: ['@config.factory', '@logger.factory']
   stanford_ssp.workgroup_api:
     class: Drupal\stanford_ssp\Service\StanfordSSPWorkgroupApi
     arguments: ['@config.factory', '@http_client', '@logger.factory']

--- a/tests/Unit/Service/StanfordSSPDrupalAuthTest.php
+++ b/tests/Unit/Service/StanfordSSPDrupalAuthTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\stanford_ssp\Kernel\Service;
+
+use Drupal\Core\Logger\LoggerChannel;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\simplesamlphp_auth\Exception\SimplesamlphpAttributeException;
+use Drupal\simplesamlphp_auth\Service\SimplesamlphpAuthManager;
+use Drupal\stanford_ssp\Service\StanfordSSPAuthManager;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class StanfordSSPDrupalAuthTest
+ *
+ * @group stanford_ssp
+ */
+class StanfordSSPDrupalAuthTest extends UnitTestCase {
+
+  /**
+   * Tests the user without a mail attribute gets an account created.
+   */
+  public function testNoAttributeError() {
+    $this->assertEquals(1, 1);
+    $saml_config = [
+      'simplesamlphp_auth.settings' => [],
+    ];
+    $config_factory = $this->getConfigFactoryStub($saml_config);
+
+    $auth_manager = new SimplesamlphpAuthManager($config_factory);
+    $this->expectException(SimplesamlphpAttributeException::class);
+    $auth_manager->getAttribute('mail');
+  }
+
+  /**
+   * Tests the user without a mail attribute gets an account created.
+   */
+  public function testNoAttributeSuccess() {
+    $this->assertEquals(1, 1);
+    $saml_config = [
+      'simplesamlphp_auth.settings' => [],
+    ];
+    $config_factory = $this->getConfigFactoryStub($saml_config);
+
+    $auth_manager = new StanfordSSPAuthManager($config_factory, $this->getLoggerFactoryStub());
+    $this->assertEquals('@stanford.edu', $auth_manager->getAttribute('mail'));
+  }
+
+  protected function getLoggerFactoryStub() {
+    $logger_channel = $this->createMock(LoggerChannel::class);
+
+    $logger = $this->createMock(LoggerChannelFactoryInterface::class);
+    $logger->method('get')->willReturn($logger_channel);
+    return $logger;
+  }
+
+}

--- a/tests/Unit/Service/StanfordSSPDrupalAuthTest.php
+++ b/tests/Unit/Service/StanfordSSPDrupalAuthTest.php
@@ -20,7 +20,6 @@ class StanfordSSPDrupalAuthTest extends UnitTestCase {
    * Tests the user without a mail attribute gets an account created.
    */
   public function testNoAttributeError() {
-    $this->assertEquals(1, 1);
     $saml_config = [
       'simplesamlphp_auth.settings' => [],
     ];
@@ -35,7 +34,6 @@ class StanfordSSPDrupalAuthTest extends UnitTestCase {
    * Tests the user without a mail attribute gets an account created.
    */
   public function testNoAttributeSuccess() {
-    $this->assertEquals(1, 1);
     $saml_config = [
       'simplesamlphp_auth.settings' => [],
     ];


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When no `mail` attribute is passed, build an email from the uid

# Needed By (Date)
- asap

# Urgency
- High. its a blocker for a user on williams in H&S

# Steps to Test
1. run unit tests.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)