### PR TITLE
rel=nofollow

### DIFF
--- a/modules/stanford_saml_block/stanford_saml_block.module
+++ b/modules/stanford_saml_block/stanford_saml_block.module
@@ -68,6 +68,9 @@ function stanford_saml_block_block_view($delta = '') {
         'query' => [
           'destination' => check_plain(current_path()),
         ],
+        'attributes' => [
+          'rel' => 'nofollow',
+        ],
       ];
 
       $block = array(

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -231,7 +231,13 @@ function stanford_simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
   $login_path = variable_get('simplesamlphp_auth_login_path', 'saml_login');
   $login_name = variable_get('simplesamlphp_auth_login_link_display_name', t('Federated Log In'));
   $destination = drupal_get_destination();
-  $link = l($login_name, $login_path, array('query' => $destination, 'attributes' => array('rel' => 'nofollow')));
+  $options = [
+    'query' => $destination,
+    'attributes' => [
+      'rel' => 'nofollow',
+    ]
+  ];
+  $link = l($login_name, $login_path, $options);
 
   // Add SAML login link to user login form.
   if ($form_id == 'user_login_block' || $form_id == 'user_account_form') {
@@ -319,7 +325,11 @@ function stanford_simplesamlphp_auth_generate_block_text() {
   else {
     $login_path = variable_get('stanford_simplesamlphp_auth_login_path', 'sso/login');
     $login_name = variable_get('stanford_simplesamlphp_auth_login_link_display_name', t('Federated Log In'));
-    $options = array('attributes' => array('rel' => 'nofollow'));
+    $options = [
+      'attributes' => [
+        'rel' => 'nofollow',
+      ]
+    ];
     $block_content .= '<p>' . l($login_name, $login_path, $options) . '</p>';
   }
 

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -230,9 +230,8 @@ function stanford_simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
 
   $login_path = variable_get('simplesamlphp_auth_login_path', 'saml_login');
   $login_name = variable_get('simplesamlphp_auth_login_link_display_name', t('Federated Log In'));
-  $destination = drupal_get_destination();
   $options = [
-    'query' => $destination,
+    'query' => drupal_get_destination(),
     'attributes' => [
       'rel' => 'nofollow',
     ]

--- a/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
+++ b/modules/stanford_simplesamlphp_auth/stanford_simplesamlphp_auth.module
@@ -231,7 +231,7 @@ function stanford_simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
   $login_path = variable_get('simplesamlphp_auth_login_path', 'saml_login');
   $login_name = variable_get('simplesamlphp_auth_login_link_display_name', t('Federated Log In'));
   $destination = drupal_get_destination();
-  $link = l($login_name, $login_path, array('query' => $destination));
+  $link = l($login_name, $login_path, array('query' => $destination, 'attributes' => array('rel' => 'nofollow')));
 
   // Add SAML login link to user login form.
   if ($form_id == 'user_login_block' || $form_id == 'user_account_form') {
@@ -319,7 +319,8 @@ function stanford_simplesamlphp_auth_generate_block_text() {
   else {
     $login_path = variable_get('stanford_simplesamlphp_auth_login_path', 'sso/login');
     $login_name = variable_get('stanford_simplesamlphp_auth_login_link_display_name', t('Federated Log In'));
-    $block_content .= '<p>' . l($login_name, $login_path) . '</p>';
+    $options = array('attributes' => array('rel' => 'nofollow'));
+    $block_content .= '<p>' . l($login_name, $login_path, $options) . '</p>';
   }
 
   return $block_content;

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -17,11 +17,11 @@ function stanford_ssp_menu() {
     'page callback' => 'stanford_ssp_sso_auth',
     'access callback' => "stanford_ssp_access_login_page",
     'type' => MENU_SUGGESTED_ITEM,
-    'options' => array(
-      'attributes' => array(
+    'options' => [
+      'attributes' => [
         'rel' => 'nofollow',
-      )
-    )
+      ]
+    ],
   );
 
   $items['sso/denied-test'] = array(

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -682,7 +682,7 @@ function stanford_ssp_form_user_login_alter(array &$form, array &$form_state) {
     $link_text = variable_get("stanford_ssp_sso_link_text", t("Log in with your SUNet ID »"));
     $form['saml_auth']['saml_link'] = array(
       '#prefix' => "<p>",
-      '#markup' => l($link_text, "sso/login"),
+      '#markup' => l($link_text, "sso/login", array('attributes' => array('rel' => 'nofollow'))),
       '#suffix' => "</p>",
     );
   }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -680,9 +680,14 @@ function stanford_ssp_form_user_login_alter(array &$form, array &$form_state) {
       '#collapsed' => FALSE,
     );
     $link_text = variable_get("stanford_ssp_sso_link_text", t("Log in with your SUNet ID »"));
+    $options = [
+      'attributes' => [
+        'rel' => 'nofollow',
+      ]
+    ];
     $form['saml_auth']['saml_link'] = array(
       '#prefix' => "<p>",
-      '#markup' => l($link_text, "sso/login", array('attributes' => array('rel' => 'nofollow'))),
+      '#markup' => l($link_text, "sso/login", $options),
       '#suffix' => "</p>",
     );
   }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -17,6 +17,11 @@ function stanford_ssp_menu() {
     'page callback' => 'stanford_ssp_sso_auth',
     'access callback' => "stanford_ssp_access_login_page",
     'type' => MENU_SUGGESTED_ITEM,
+    'options' => array(
+      'attributes' => array(
+        'rel' => 'nofollow',
+      )
+    )
   );
 
   $items['sso/denied-test'] = array(


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add `rel="nofollow"` to all `sso/login` links.

# Needed By (Date)
- Sometime

# Criticality
- How critical is this PR on a 1-10 scale? 3/10
- Affects all sites and should cut down on drupal bootstraps

# Steps to Test

1. Go to https://20190620jsa-dev.sites.stanford.edu/ as an anonymous user
2. Check that the "SUNetID Login" link in the global header has a `rel="nofollow"` attribute
3. Go to https://20190620jsa-dev.sites.stanford.edu/user
4. Check that the "Log in with your SUNetID" link has a `rel="nofollow"` attribute

# Affected Projects or Products
- Everything that uses stanford_ssp

# Associated Issues and/or People
- Anyone who should be notified? ( @pookmish )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)