### PR TITLE
Add rel="nofollow" attribute

### DIFF
--- a/src/Plugin/Block/SamlLoginBlock.php
+++ b/src/Plugin/Block/SamlLoginBlock.php
@@ -60,7 +60,7 @@ class SamlLoginBlock extends BlockBase {
    */
   public function build() {
     $build = [];
-    $build['saml_link'] = Link::createFromRoute($this->configuration['link_text'], 'simplesamlphp_auth.saml_login', [], ['rel' => 'nofollow'])
+    $build['saml_link'] = Link::createFromRoute($this->configuration['link_text'], 'simplesamlphp_auth.saml_login', [], ['attributes' => ['rel' => 'nofollow']])
       ->toRenderable();
     return $build;
   }

--- a/src/Plugin/Block/SamlLoginBlock.php
+++ b/src/Plugin/Block/SamlLoginBlock.php
@@ -60,7 +60,7 @@ class SamlLoginBlock extends BlockBase {
    */
   public function build() {
     $build = [];
-    $build['saml_link'] = Link::createFromRoute($this->configuration['link_text'], 'simplesamlphp_auth.saml_login')
+    $build['saml_link'] = Link::createFromRoute($this->configuration['link_text'], 'simplesamlphp_auth.saml_login', [], ['rel' => 'nofollow'])
       ->toRenderable();
     return $build;
   }

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -24,6 +24,7 @@ function stanford_ssp_config_schema_info_alter(&$definitions) {
 function stanford_ssp_form_user_login_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (isset($form['simplesamlphp_auth_login_link'])) {
     $form['simplesamlphp_auth_login_link']['#attributes']['class'][] = 'decanter-button';
+    $form['simplesamlphp_auth_login_link']['#attributes']['rel'] = 'nofollow';
     $config = \Drupal::config('stanford_ssp.settings');
 
     // If configured to disallow local login, hide the local login form parts.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add `rel="nofollow"` attribute to login link

# Needed By (Date)
- Sometime

# Criticality
- How critical is this PR on a 1-10 scale? 2/10
- Cuts down on extraneous robot requests (we hope)

# Steps to Test

1. Check out this branch
2. Go to `/user`
3. Verify that the SAML login link has a `rel="nofollow"` attribute

# Affected Projects or Products
- D8 sites

# Associated Issues and/or People
- Other PRs: #73 
- Anyone who should be notified? ( @sherakama )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)