### PR TITLE
Added a redirection route from /sso/login to /saml_login

### DIFF
--- a/stanford_ssp.routing.yml
+++ b/stanford_ssp.routing.yml
@@ -21,3 +21,13 @@ stanford_ssp.create_user:
     _title: 'Add SAML User'
   requirements:
     _permission: 'administer users'
+
+stanford_ssp.sso_login:
+  path: '/sso/login'
+  defaults:
+    _route: 'simplesamlphp_auth.saml_login'
+  requirements:
+    _user_is_logged_in: 'FALSE'
+  options:
+    _maintenance_access: TRUE
+    no_cache: TRUE

--- a/tests/src/Kernel/Form/AuthorizationsFormTest.php
+++ b/tests/src/Kernel/Form/AuthorizationsFormTest.php
@@ -57,15 +57,25 @@ class AuthorizationsFormTest extends KernelTestBase {
     \Drupal::formBuilder()
       ->submitForm('\Drupal\stanford_ssp\Form\AuthorizationsForm', $form_state);
 
-    $this->assertArraySubset([
-      'group1',
-      'group2',
-    ], \Drupal::config('stanford_ssp.settings')->get('whitelist_groups'));
+    /**
+     * assertArraySubset is deprecated
+     * see: https://github.com/sebastianbergmann/phpunit/issues/3494
+     */
+    // $this->assertArraySubset([
+    //  'group1',
+    // 'group2',
+    //], \Drupal::config('stanford_ssp.settings')->get('whitelist_groups'));
 
-    $this->assertArraySubset([
-      'user1',
-      'user2',
-    ], \Drupal::config('stanford_ssp.settings')->get('whitelist_users'));
+    $this->assertTrue(in_array('group1', \Drupal::config('stanford_ssp.settings')->get('whitelist_groups')));
+    $this->assertTrue(in_array('group2', \Drupal::config('stanford_ssp.settings')->get('whitelist_groups')));
+
+    //$this->assertArraySubset([
+    //  'user1',
+    //  'user2',
+    //], \Drupal::config('stanford_ssp.settings')->get('whitelist_users'));
+
+    $this->assertTrue(in_array('user1', \Drupal::config('stanford_ssp.settings')->get('whitelist_users')));
+    $this->assertTrue(in_array('user2', \Drupal::config('stanford_ssp.settings')->get('whitelist_users')));
 
   }
 

--- a/tests/src/Kernel/Form/AuthorizationsFormTest.php
+++ b/tests/src/Kernel/Form/AuthorizationsFormTest.php
@@ -57,26 +57,10 @@ class AuthorizationsFormTest extends KernelTestBase {
     \Drupal::formBuilder()
       ->submitForm('\Drupal\stanford_ssp\Form\AuthorizationsForm', $form_state);
 
-    /**
-     * assertArraySubset is deprecated
-     * see: https://github.com/sebastianbergmann/phpunit/issues/3494
-     */
-    // $this->assertArraySubset([
-    //  'group1',
-    // 'group2',
-    //], \Drupal::config('stanford_ssp.settings')->get('whitelist_groups'));
-
     $this->assertTrue(in_array('group1', \Drupal::config('stanford_ssp.settings')->get('whitelist_groups')));
     $this->assertTrue(in_array('group2', \Drupal::config('stanford_ssp.settings')->get('whitelist_groups')));
-
-    //$this->assertArraySubset([
-    //  'user1',
-    //  'user2',
-    //], \Drupal::config('stanford_ssp.settings')->get('whitelist_users'));
-
     $this->assertTrue(in_array('user1', \Drupal::config('stanford_ssp.settings')->get('whitelist_users')));
     $this->assertTrue(in_array('user2', \Drupal::config('stanford_ssp.settings')->get('whitelist_users')));
-
   }
 
 }

--- a/tests/src/Kernel/Routing/RouteSubscriber/RouteSubscriberTest.php
+++ b/tests/src/Kernel/Routing/RouteSubscriber/RouteSubscriberTest.php
@@ -44,7 +44,7 @@ class RouteSubscriberTest extends KernelTestBase {
 
     /** covers the redirect from '/sso/login' to '/saml_login' */
     $route = $route_provider->getRouteByName('stanford_ssp.sso_login');
-    $this->assertEquals('/saml_login', $route->getPath());
+    $this->assertEquals('/sso/login', $route->getPath());
   }
 
 }

--- a/tests/src/Kernel/Routing/RouteSubscriber/RouteSubscriberTest.php
+++ b/tests/src/Kernel/Routing/RouteSubscriber/RouteSubscriberTest.php
@@ -41,6 +41,10 @@ class RouteSubscriberTest extends KernelTestBase {
 
     $route = $route_provider->getRouteByName('simplesamlphp_auth.admin_settings_local');
     $this->assertEquals('Drupal\stanford_ssp\Form\LocalLoginForm', $route->getDefault('_form'));
+
+    /** covers the redirect from '/sso/login' to '/saml_login' */
+    $route = $route_provider->getRouteByName('stanford_ssp.sso_login');
+    $this->assertEquals('/saml_login', $route->getPath());
   }
 
 }

--- a/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
+++ b/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
@@ -73,10 +73,18 @@ class SamlLoginBlockTest extends UnitTestCase {
     $build = $this->block->build();
     $this->assertCount(1, $build);
     $this->assertArrayHasKey('saml_link', $build);
-    $this->assertArraySubset([
-      '#type' => 'link',
-      '#title' => 'SUNetID Login',
-    ], $build['saml_link']);
+
+    /**
+     * assertArraySubset is deprecated.
+     */
+    //$this->assertArraySubset([
+    //  '#type' => 'link',
+    //  '#title' => 'SUNetID Login',
+    //], $build['saml_link']);
+
+    $this->assertTrue($build['saml_link']['#type'] == 'link');
+    $this->assertTrue($build['saml_link']['#title'] == 'SUNetID Login');
+
     $this->assertInstanceOf('\Drupal\Core\Url', $build['saml_link']['#url']);
   }
 

--- a/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
+++ b/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
@@ -73,18 +73,8 @@ class SamlLoginBlockTest extends UnitTestCase {
     $build = $this->block->build();
     $this->assertCount(1, $build);
     $this->assertArrayHasKey('saml_link', $build);
-
-    /**
-     * assertArraySubset is deprecated.
-     */
-    //$this->assertArraySubset([
-    //  '#type' => 'link',
-    //  '#title' => 'SUNetID Login',
-    //], $build['saml_link']);
-
     $this->assertTrue($build['saml_link']['#type'] == 'link');
     $this->assertTrue($build['saml_link']['#title'] == 'SUNetID Login');
-
     $this->assertInstanceOf('\Drupal\Core\Url', $build['saml_link']['#url']);
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- For D8CORE-1118, we want a redirect route from /sso/login, which is the traditional SSO url, to /saml_login, which is the D8 version of the SSO url.  We also don't want to disturb any other links to the D8 version.

# Needed By 
- Fix version is RC-2 for the D8CORE project

# Urgency
- not critical.

# Steps to Test

1. In a D8 instance, with SSO configured,
2.  Visit `/sso/login`
2.  Observe that you are redirected to `/saml_login`, and then on to the SSO sign in page.

# Affected Projects or Products
- Only affects the `stanford_ssp` module.
- Depends on the `simplesamlphp` module

# Associated Issues and/or People
- D8Core-1118

# Checklist

- [X] Unit Test provided
- [X] Does this require a behat test?
  - no.
- [X] Deprecated code removed
- [X] Is all markup and styles accessible?
- [X] Syntax & Formatting is correct (Code Climate should take care of this)
- [X] Is the approach to the problem appropriate?
- [X] Can anything be simplified?
  - I don't believe so.
- [X] Is the code too specific to _ and needs generalization:
  * Site? - nope
  * Product? - nope
  * Stanford? - it's generalized to Stanford D8 generally.
- [X] Do forms need to sanitized
  - no changes to forms.
- [x] Any obvious security flaws or potential holes
  - nope.
- [X] Are the naming conventions appropriate?
  - part of the point was to normalize the route naming to match our convention.
- [X] Are there enough comments inline with the code?
- [X] Is there documentation needed?
  - no additional documentation required
- [X] Is there anything included that should not be?
  - no
- [x] Are all dependencies declared?
  - no changes to dependencies
- [X] Does the PR follow development standards?
- [X] Are all content (labels and other strings) translated?
  - no changes to strings.
- [X] Is there anything in this code that would be hidden or hard to discover through the UI?
  - none of the changes affect the UI, with the exception of providing a standard route.
- [X] Are there any code smells? https://blog.codinghorror.com/code-smells/
  - I don't think so.