### PR TITLE
D8CORE-1243 Fix role mapping form ajax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 ## Defines images and working directory.
 defaults: &defaults
   docker:
-    - image: pookmish/drupal8ci:latest
+    - image: pookmish/drupal8ci:pcov
     - image: selenium/standalone-chrome:3.141.59-neon
     - image: mariadb:10.3
       environment:

--- a/src/Form/RoleSyncForm.php
+++ b/src/Form/RoleSyncForm.php
@@ -77,7 +77,10 @@ class RoleSyncForm extends SyncingSettingsForm {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
 
-    if (!$form_state->get('mappings')) {
+    // If the form is newly built, the form state storage will be null. If the
+    // form is being rebuilt from an ajax, the storage will be some type of
+    // array.
+    if (is_null($form_state->get('mappings'))) {
       $mappings = explode('|', $form['user_info']['role_population']['#default_value']);
       $form_state->set('mappings', array_filter(array_combine($mappings, $mappings)));
     }
@@ -204,7 +207,7 @@ class RoleSyncForm extends SyncingSettingsForm {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   protected function buildRoleRow($role_mapping_string) {
-    list($role_id, $comparison) = explode(':', $role_mapping_string, 2);
+    [$role_id, $comparison] = explode(':', $role_mapping_string, 2);
 
     $exploded_comparison = explode(',', $comparison, 3);
 
@@ -304,14 +307,22 @@ class RoleSyncForm extends SyncingSettingsForm {
     $cert_path = $form_state->getValue('workgroup_api_cert');
     $key_path = $form_state->getValue('workgroup_api_key');
 
-    // Both cert and Key have to be selected.
+    // When the cert values are overridden by settings.php, we will skip
+    // validating the files are accurate.
+    if (self::hasOverriddenApiCert()) {
+      return;
+    }
+
+    // Both cert and Key have to be populated.
     if (!$cert_path || !$key_path) {
       $form_state->setError($form['user_info']['workgroup_api_cert'], $this->t('Cert and Key are required if using workgroup API.'));
+      return;
     }
 
     // User error when they put in the same path for both cert and key.
     if ($cert_path == $key_path) {
       $form_state->setError($form['user_info']['workgroup_api_cert'], $this->t('Cert and Key must be different.'));
+      return;
     }
 
     if (!is_file($cert_path)) {
@@ -355,6 +366,11 @@ class RoleSyncForm extends SyncingSettingsForm {
   protected function getDefaultSamlAttribute() {
     return $this->config('stanford_ssp.settings')
       ->get('saml_attribute') ?: 'eduPersonEntitlement';
+  }
+
+  protected static function hasOverriddenApiCert() {
+    $config = \Drupal::config('stanford_ssp.settings');
+    return $config->hasOverrides('workgroup_api_cert') && $config->hasOverrides('workgroup_api_key');
   }
 
 }

--- a/src/Form/RoleSyncForm.php
+++ b/src/Form/RoleSyncForm.php
@@ -334,14 +334,12 @@ class RoleSyncForm extends SyncingSettingsForm {
     }
 
     // Dont bother testing the workgroup api connection if there are any errors.
-    if ($form_state::hasAnyErrors()) {
-      return;
-    }
-
-    $this->workgroupApi->setCert($cert_path);
-    $this->workgroupApi->setKey($key_path);
-    if (!$this->workgroupApi->connectionSuccessful()) {
-      $form_state->setError($form['user_info']['workgroup_api_cert'], $this->t('Cert information invalid. See database logs for more information.'));
+    if (!$form_state::hasAnyErrors()) {
+      $this->workgroupApi->setCert($cert_path);
+      $this->workgroupApi->setKey($key_path);
+      if (!$this->workgroupApi->connectionSuccessful()) {
+        $form_state->setError($form['user_info']['workgroup_api_cert'], $this->t('Cert information invalid. See database logs for more information.'));
+      }
     }
   }
 
@@ -368,6 +366,12 @@ class RoleSyncForm extends SyncingSettingsForm {
       ->get('saml_attribute') ?: 'eduPersonEntitlement';
   }
 
+  /**
+   * Check if the api cert paths are overridden by some other manner.
+   *
+   * @return bool
+   *   If the cert and key paths are overridden.
+   */
   protected static function hasOverriddenApiCert() {
     $config = \Drupal::config('stanford_ssp.settings');
     return $config->hasOverrides('workgroup_api_cert') && $config->hasOverrides('workgroup_api_key');

--- a/src/Form/RoleSyncForm.php
+++ b/src/Form/RoleSyncForm.php
@@ -309,20 +309,20 @@ class RoleSyncForm extends SyncingSettingsForm {
 
     // When the cert values are overridden by settings.php, we will skip
     // validating the files are accurate.
+    // @codeCoverageIgnoreStart
     if (self::hasOverriddenApiCert()) {
       return;
     }
+    // @codeCoverageIgnoreEnd
 
     // Both cert and Key have to be populated.
     if (!$cert_path || !$key_path) {
       $form_state->setError($form['user_info']['workgroup_api_cert'], $this->t('Cert and Key are required if using workgroup API.'));
-      return;
     }
 
     // User error when they put in the same path for both cert and key.
     if ($cert_path == $key_path) {
       $form_state->setError($form['user_info']['workgroup_api_cert'], $this->t('Cert and Key must be different.'));
-      return;
     }
 
     if (!is_file($cert_path)) {
@@ -371,6 +371,9 @@ class RoleSyncForm extends SyncingSettingsForm {
    *
    * @return bool
    *   If the cert and key paths are overridden.
+   *
+   * @codeCoverageIgnore
+   *   Ignore so that we can simulate this in the test.
    */
   protected static function hasOverriddenApiCert() {
     $config = \Drupal::config('stanford_ssp.settings');

--- a/tests/src/Unit/Service/StanfordSSPAuthManagerTest.php
+++ b/tests/src/Unit/Service/StanfordSSPAuthManagerTest.php
@@ -75,7 +75,7 @@ class StanfordSSPAuthManagerTest extends UnitTestCase {
   /**
    * Get a logger factory mock object.
    *
-   * @return \PHPUnit_Framework_MockObject_MockObject
+   * @return \PHPUnit\Framework\MockObject\MockObject
    */
   protected function getLoggerFactoryStub() {
     $logger_channel = $this->createMock(LoggerChannel::class);

--- a/tests/src/Unit/Service/StanfordSSPDrupalAuthTest.php
+++ b/tests/src/Unit/Service/StanfordSSPDrupalAuthTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\stanford_ssp\Unit\Service;
 
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
@@ -12,6 +13,7 @@ use Drupal\stanford_ssp\Service\StanfordSSPWorkgroupApiInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\user\UserInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Class StanfordSSPDrupalAuthTest
@@ -41,44 +43,78 @@ class StanfordSSPDrupalAuthTest extends UnitTestCase {
    */
   protected function setUp() {
     parent::setUp();
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
 
+  /**
+   * Get the created service for testing.
+   *
+   * @param bool $return_account
+   *   If the external auth service should return an account.
+   * @param int $role_setting
+   *   What the simplesamlphp_auth.settings config value is.
+   * @param bool $return_attributes
+   *   If the auth manager service should return attributes.
+   *
+   * @return \Drupal\stanford_ssp\Service\StanfordSSPDrupalAuth
+   *   Constructed service.
+   */
+  protected function getService($return_account = TRUE, $role_setting = 1, $return_attributes = TRUE) {
     $this->removeRole = $this->randomMachineName();
     $this->addRole = $this->randomMachineName();
 
     $auth = $this->createMock(StanfordSSPAuthManager::class);
-    $auth->method('getAttributes')->willReturn(['eduPersonAffiliation' => ['staff']]);
+    $auth->method('getAttributes')
+      ->willReturn($return_attributes ? ['eduPersonAffiliation' => ['staff']] : NULL);
 
     $config_factory = $this->getConfigFactoryStub([
       'simplesamlphp_auth.settings' => [
-        'role' => ['eval_every_time' => 1],
+        'role' => ['eval_every_time' => $role_setting],
         'debug' => TRUE,
+        'register_users' => TRUE,
       ],
       'stanford_ssp.settings' => [
         'use_workgroup_api' => TRUE,
       ],
     ]);
-    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
-    $logger = $this->createMock(LoggerInterface::class);
-    $external_auth = $this->createMock(ExternalAuthInterface::class);
-
     $account = $this->createMock(UserInterface::class);
     $account->method('getRoles')->willReturn([$this->removeRole]);
     $account->method('removeRole')->willReturn(TRUE);
 
-    $external_auth->method('login')->willReturn($account);
+    $entity_storage = $this->createMock(EntityStorageInterface::class);
+    $entity_storage->method('loadByProperties')->willReturn([]);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->willReturn($entity_storage);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $external_auth = $this->createMock(ExternalAuthInterface::class);
+
+    $external_auth->method('login')->willReturn($return_account ? $account : NULL);
     $messenger = $this->createMock(MessengerInterface::class);
     $module_handler = $this->createMock(ModuleHandlerInterface::class);
     $workgroup_api = $this->createMock(StanfordSSPWorkgroupApiInterface::class);
     $workgroup_api->method('getRolesFromAuthName')->willReturn([$this->addRole]);
 
-    $this->service = new StanfordSSPDrupalAuth($auth, $config_factory, $entity_type_manager, $logger, $external_auth, $account, $messenger, $module_handler, $workgroup_api);
+    return new StanfordSSPDrupalAuth($auth, $config_factory, $entity_type_manager, $logger, $external_auth, $account, $messenger, $module_handler, $workgroup_api);
   }
 
   /**
    * Test role sync.
    */
   public function testRoleSync() {
-    $user = $this->service->externalLoginRegister($this->randomMachineName());
+    $service = $this->getService();
+    $user = $service->externalLoginRegister($this->randomMachineName());
+    $this->assertInstanceOf(UserInterface::class, $user);
+
+    $service = $this->getService(FALSE);
+    $user = $service->externalLoginRegister($this->randomMachineName());
+    $this->assertNull($user);
+
+    $service = $this->getService(TRUE, 2, FALSE);
+    $user = $service->externalLoginRegister($this->randomMachineName());
     $this->assertInstanceOf(UserInterface::class, $user);
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed validation error if the cert and key are overridden via settings.php.
- Fixed logic error when deleting the last role mapping. It wasn't actually deleting it.

# Need Review By (Date)
- 2/12

# Urgency
- low

# Steps to Test
1. checkout this branch
1. on /admin/config/people/simplesamlphp_auth/sync add and delete role mapping
1. verify it works as expected.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
