### PR TITLE
Release 8.1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,17 +57,44 @@ behat: &behat
     - store_artifacts:
         path: /var/www/html/artifacts
 
+back_to_dev: &back_to_dev
+  <<: *defaults
+  steps:
+    - checkout
+    - run:
+        name: Back to dev
+        command: |
+          composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
+          ~/.composer/vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY}
+
 # Declare all of the jobs we should run.
 jobs:
   run-coverage:
     <<: *code_coverage
   run-behat:
     <<: *behat
+  run-back-to-dev:
+    <<: *back_to_dev
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
   version: 2
-  weekly:
+  after_release:
+    jobs:
+      - run-back-to-dev:
+          filters:
+            tags:
+              only:
+                - /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?$/
+            branches:
+              ignore:
+                - /.*/
+  tests:
+    jobs:
+      - run-coverage
+      - run-behat
+  # Re-test every sunday in case this code becomes stale.
+  sundays:
     jobs:
       - run-coverage
       - run-behat
@@ -78,8 +105,3 @@ workflows:
             branches:
               only:
                 - 8.x-1.x
-  tests:
-    jobs:
-      - run-coverage
-      - run-behat
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+# .github/workflows/release.yml
+name: Release
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag
+        uses: K-Phoen/semver-release-action@master
+        with:
+          release_branch: master
+          tag_format: "%major%.%minor%.%patch%"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 --------------------------------------------------------------------------------
 _Release Date: 2020-04-16_
 
+* 8.1.4 (d8fec1e)
 * D8CORE-1644: Dev branch workflow (1877202)
+* D8CORE-1545 Added validation to check for public workgroups (#89) (a0acd1d)* D8CORE-1644: Dev branch workflow (1877202)
 * D8CORE-1545 Added validation to check for public workgroups (#89) (a0acd1d)* D8CORE-1644: Dev branch workflow (1877202)
 * D8CORE-1545 Added validation to check for public workgroups (#89) (a0acd1d)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Stanford SSP
 
+8.1.4
+--------------------------------------------------------------------------------
+_Release Date: 2020-04-16_
+
+* D8CORE-1644: Dev branch workflow (1877202)
+* D8CORE-1545 Added validation to check for public workgroups (#89) (a0acd1d)* D8CORE-1644: Dev branch workflow (1877202)
+* D8CORE-1545 Added validation to check for public workgroups (#89) (a0acd1d)
+
 8.x-1.3
 --------------------------------------------------------------------------------
 _Release Date: 2020-03-20_

--- a/README.md
+++ b/README.md
@@ -39,3 +39,19 @@ Contribution / Collaboration
 You are welcome to contribute functionality, bug fixes, or documentation to this module. If you would like to suggest a fix or new functionality you may add a new issue to the GitHub issue queue or you may fork this repository and submit a pull request. For more help please see [GitHub's article on fork, branch, and pull requests](https://help.github.com/articles/using-pull-requests)
 
 [![CircleCI](https://circleci.com/gh/SU-SWS/stanford_ssp/tree/8.x-1.x.svg?style=svg)](https://circleci.com/gh/SU-SWS/stanford_ssp/tree/8.x-1.x)
+
+
+Releases
+---
+
+Steps to build a new release:
+- Checkout the latest commit from the `8.x-1.x` branch.
+- Create a new branch for the release.
+- Commit any necessary changes to the release branch.
+  -  These may include, but are not necessarily limited to:
+    - Update the version in any `info.yml` files, including in any submodules.
+    - Update the CHANGELOG to reflect the changes made in the new release.
+- Make a PR to merge your release branch into `master`
+- Give the PR a semver-compliant label, e.g., (`patch`, `minor`, `major`).  This may happen automatically via Github actions (if a labeler action is configured).
+- When the PR is merged to `master`, a new tag will be created automatically, bumping the version by the semver label.
+- The github action is built from: [semver-release-action](https://github.com/K-Phoen/semver-release-action), and further documentation is available there.

--- a/src/Service/StanfordSSPWorkgroupApiInterface.php
+++ b/src/Service/StanfordSSPWorkgroupApiInterface.php
@@ -99,4 +99,15 @@ interface StanfordSSPWorkgroupApiInterface {
    */
   public function userInAllGroups(array $workgroups, $name);
 
+  /**
+   * Check if the workgroup is valid and is public.
+   *
+   * @param string $workgroup
+   *   Workgroup name to test.
+   *
+   * @return bool|null
+   *   True if the given workgroup is valid, null if unknown.
+   */
+  public function isWorkgroupValid($workgroup);
+
 }

--- a/stanford_ssp.info.yml
+++ b/stanford_ssp.info.yml
@@ -3,7 +3,7 @@ description: Configures SimpleSAML PHP auth to work in Stanford web environment
 core: 8.x
 core_version_requirement: ^8 || ^9
 type: module
-version: 8.x-1.4-dev
+version: 8.x-1.4
 package: Stanford
 dependencies:
   - simplesamlphp_auth:simplesamlphp_auth

--- a/stanford_ssp.info.yml
+++ b/stanford_ssp.info.yml
@@ -3,7 +3,7 @@ description: Configures SimpleSAML PHP auth to work in Stanford web environment
 core: 8.x
 core_version_requirement: ^8 || ^9
 type: module
-version: 8.x-1.3
+version: 8.x-1.4-dev
 package: Stanford
 dependencies:
   - simplesamlphp_auth:simplesamlphp_auth

--- a/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
+++ b/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
@@ -3,10 +3,13 @@
 namespace Drupal\Tests\stanford_ssp\Unit\Service;
 
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\stanford_ssp\Service\StanfordSSPWorkgroupApi;
 use Drupal\Tests\UnitTestCase;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ClientException;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Class StanfordSSPWorkgroupApi.
@@ -29,6 +32,13 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
    * @var string
    */
   protected $authname;
+
+  /**
+   * If the guzzle callback should throw an error.
+   *
+   * @var bool
+   */
+  protected $throwGuzzleException = FALSE;
 
   /**
    * {@inheritDoc}
@@ -57,11 +67,16 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
       ->will($this->returnCallback([$this, 'guzzleRequestCallback']));
 
     $logger = $this->createMock(LoggerChannelFactoryInterface::class);
-
+    $logger->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
     $this->service = new StanfordSSPWorkgroupApi($config_factory, $guzzle, $logger);
   }
 
   public function guzzleRequestCallback($method, $url) {
+    if ($this->throwGuzzleException) {
+      $request = $this->createMock(RequestInterface::class);
+      throw new ClientException('It broke', $request);
+    }
+
     $guzzle_response = $this->createMock(ResponseInterface::class);
     $guzzle_response->method('getStatusCode')->willReturn(200);
 
@@ -71,6 +86,13 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
         $body = "<members><member id='{$this->authname}'/></members>";
         break;
 
+      case 'https://workgroupsvc.stanford.edu/v1/workgroups/foo:bar':
+        $body = "<visibility>STANFORD</visibility>";
+        break;
+
+      case 'https://workgroupsvc.stanford.edu/v1/workgroups/bar:foo':
+        $body = "<workgroup><visibility>PRIVATE</visibility></workgroup>";
+        break;
     }
     $guzzle_response->method('getBody')->willReturn($body);
     return $guzzle_response;
@@ -104,6 +126,23 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
       'valid:workgroup',
     ], $this->authname));
     $this->assertTrue($this->service->userInAllGroups(['valid:workgroup'], $this->authname));
+  }
+
+  /**
+   * Valid workgroups are public.
+   */
+  public function testValidWorkgroup() {
+    $this->assertTrue($this->service->isWorkgroupValid('foo:bar'));
+    $this->assertFalse($this->service->isWorkgroupValid('bar:foo'));
+  }
+
+  /**
+   * Guzzle exceptions don't break the service.
+   */
+  public function testGuzzleException() {
+    $this->throwGuzzleException = TRUE;
+    $this->assertFalse($this->service->isWorkgroupValid('foo:bar'));
+    $this->assertFalse($this->service->userInGroup('foo', 'bar'));
   }
 
 }


### PR DESCRIPTION
# What
- Validate that the workgroups entered are public when using the workgroup API

# So what
- Users won't be able to enter private workgroups and be confused when the role mapping doesn't work.

# Now what
- Deploy & Clear cache 

# New Requirements and Risks
- None

Changes:
https://github.com/SU-SWS/stanford_ssp/compare/release-8.1.4