### PR TITLE
SOEOP-402 - Added conditional to prevent error.

### DIFF
--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -251,7 +251,7 @@ function stanford_ssp_sso_auth() {
  * Also enforces secure cookies on https.
  *
  * Update: The cookie appears to be set in webauth module.
- * Leavning the ini_set in just in case. However, it now checks for the cookie session just in case there are times it is not set. 
+ * Leaving the ini_set in just in case. However, it now checks for the cookie session just in case there are times it is not set.
  */
 function stanford_ssp_force_https() {
 

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -249,12 +249,15 @@ function stanford_ssp_sso_auth() {
  *
  * Checks to ensure user is on https and will force redirect if option is on.
  * Also enforces secure cookies on https.
+ *
+ * Update: The cookie appears to be set in webauth module.
+ * Leavning the ini_set in just in case. However, it now checks for the cookie session just in case there are times it is not set. 
  */
 function stanford_ssp_force_https() {
 
   global $is_https;
   // If is https force secure cookies. Mmmmm cookies.
-  if ($is_https) {
+  if ($is_https && !ini_get('session.cookie_secure')) {
     if (session_status() == PHP_SESSION_NONE) {
       // Mandate secure cookies for sessions.
       ini_set('session.cookie_secure', 1);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The logs report the following warning:  `ini_set(): A session is active. You cannot change the session module's ini settings at this time in stanford_ssp_force_https() (line 254 of /mnt/www/html/swssoe/docroot/sites/all/modules/stanford/stanford_ssp/stanford_ssp.module`.
- The problem. Another Stanford module by the name of Webauth has already called `[ini_set()](https://github.com/Stanford/WMD/blob/7894e24736471773ab19f27698fafed5f7830079/webauth.module#L24)` method, which is probably what makes ini_set() in the other module create the warning. 
- Solution, while it's possible to remove `ini_set` (cookie_session.secure is already set to '1') from the stanford_ssp module, I'm not sure why it was placed there in the first place. Leaving it in, but wrapped around a condition that checks for cookie session first.

# Review By (Date)
1/6

# Criticality
- Low: It's a PHP warning

# Associated Issues and/or People
- https://stanfordits.atlassian.net/jira/software/c/projects/SOEOP/issues/SOEOP-402?filter=myopenissues
- 
# Reference
- https://www.php.net/manual/en/function.ini-set.php
