### PR TITLE
D8CORE-4083 Use API V2 for the new workgroup API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Stanford SSP
 
+8.x-2.x
+--------------------------------------------------------------------------------
+- Replaced Workgroup API from V1 to V2
+  - V1 used XML, V2 uses JSON
+  - Workgroup API url has been removed from the config. It can now be configured in settings.php files with `$settings['stanford_ssp.workgroup_api'] = 'http://foo.bar';'`
+  - Workgoup API certificates for V1 do not automatically work for V2. Database updates check for a successful connection and will error out if the certificates are not valid.
+
 8.x-1.7
 --------------------------------------------------------------------------------
 _Release Date: 2021-04-09_

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Stanford Simple SAML PHP](https://github.com/SU-SWS/stanford_ssp)
-##### Version: 8.x-1.3
+##### Version: 8.x-2.x
 
 [![CircleCI](https://circleci.com/gh/SU-SWS/stanford_ssp.svg?style=svg)](https://circleci.com/gh/SU-SWS/stanford_ssp)
 [![Maintainability](https://api.codeclimate.com/v1/badges/d597c026202dc075d677/maintainability)](https://codeclimate.com/github/SU-SWS/stanford_ssp/maintainability)
@@ -28,6 +28,9 @@ Configuration
 
 The main configuration page can be found at: `/admin/config/people/simplesamlphp_auth`
 
+To use the workgroup API, you must work with the MAIS team to get a valid certificate. V1 API certificates do not automatically
+work with the V2 API.
+
 Troubleshooting
 ---
 
@@ -45,7 +48,7 @@ Releases
 ---
 
 Steps to build a new release:
-- Checkout the latest commit from the `8.x-1.x` branch.
+- Checkout the latest commit from the `8.x-2.x` branch.
 - Create a new branch for the release.
 - Commit any necessary changes to the release branch.
   -  These may include, but are not necessarily limited to:

--- a/config/install/stanford_ssp.settings.yml
+++ b/config/install/stanford_ssp.settings.yml
@@ -1,5 +1,5 @@
 saml_attribute: eduPersonEntitlement
-workgroup_api_url: 'https://workgroupsvc.stanford.edu/v1/workgroups'
+
 use_workgroup_api: false
 hide_local_login: true
 workgroup_api_cert: ''

--- a/config/schema/stanford_ssp.schema.yml
+++ b/config/schema/stanford_ssp.schema.yml
@@ -9,9 +9,6 @@ stanford_ssp.settings:
     saml_attribute:
       type: string
       label: 'Attribute in SAML that contains the role mapping values'
-    workgroup_api_url:
-      type: string
-      label: 'Workgroup API Base URL'
     hide_local_login:
       type: boolean
       label: 'Hide core local login form on user page'

--- a/src/Service/StanfordSSPWorkgroupApi.php
+++ b/src/Service/StanfordSSPWorkgroupApi.php
@@ -4,6 +4,7 @@ namespace Drupal\stanford_ssp\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Site\Settings;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
@@ -195,9 +196,9 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
         'id' => $workgroup ?: $sunet,
       ],
     ];
-
+    $api_url = Settings::get('stanford_ssp.workgroup_api', self::WORKGROUP_API);
     try {
-      $result = $this->guzzle->request('GET', self::WORKGROUP_API, $options);
+      $result = $this->guzzle->request('GET', $api_url, $options);
       return json_decode($result->getBody(), TRUE);
     }
     catch (GuzzleException $e) {

--- a/src/Service/StanfordSSPWorkgroupApi.php
+++ b/src/Service/StanfordSSPWorkgroupApi.php
@@ -176,8 +176,10 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
   /**
    * Call the workgroup api and get the response for the workgroup.
    *
-   * @param string $workgroup
+   * @param string|null $workgroup
    *   Workgroup name like uit:sws.
+   * @param string|null $sunet
+   *   User sunetid.
    *
    * @return bool|\Psr\Http\Message\ResponseInterface
    *   API response or false if fails.

--- a/src/Service/StanfordSSPWorkgroupApi.php
+++ b/src/Service/StanfordSSPWorkgroupApi.php
@@ -14,6 +14,8 @@ use GuzzleHttp\Exception\GuzzleException;
  */
 class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
 
+  const WORKGROUP_API = 'https://workgroupsvc.stanford.edu/workgroups/2.0';
+
   /**
    * Config factory service.
    *
@@ -34,13 +36,6 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
    * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
-
-  /**
-   * Keyed array of workgroup responses with the group as the key.
-   *
-   * @var array
-   */
-  protected $workgroupResponses;
 
   /**
    * Path to cert file.
@@ -113,8 +108,7 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
    * {@inheritdoc}
    */
   public function connectionSuccessful() {
-    $response = $this->getWorkgroupApiResponse('uit:sws');
-    return $response && $response->getStatusCode() == 200;
+    return !empty($this->callApi('uit:sws'));
   }
 
   /**
@@ -126,75 +120,57 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
       return $roles;
     }
     $config = $this->configFactory->get('simplesamlphp_auth.settings');;
-    $workgroup_mappings = array_filter(explode('|', $config->get('role.population') ?: ''));
+    $role_population = array_filter(explode('|', $config->get('role.population') ?: ''));
+    $workgroup_mappings = [];
 
-    // Loop through each workgroup mapping and find out if the given user exists
-    // within each group.
-    foreach ($workgroup_mappings as $workgroup_mapping) {
-      [$role, $mapping] = explode(':', $workgroup_mapping, 2);
-
+    // Convert the simplesamlphp_auth role mapping to a nested array of
+    // workgroup name => array of roles.
+    foreach ($role_population as $rule) {
+      [$role, $mapping] = explode(':', $rule, 2);
       // We ignore the eduEntitlement equation since its only a yes or no if the
       // user is in the group.
       $workgroup = substr($mapping, strrpos($mapping, ',') + 1);
-      if (!in_array($role, $roles) && $this->userInGroup($workgroup, $authname)) {
-        $roles[] = $role;
+      $workgroup_mappings[$workgroup][] = $role;
+    }
+
+    $users_workgroups = $this->getAllUserWorkgroups($authname);
+
+    // Loop through the workgroup mappings to find the ones the current user
+    // is a member of and add those roles to the list.
+    foreach ($workgroup_mappings as $workgroup => $workgroup_roles) {
+      if (in_array($workgroup, $users_workgroups)) {
+        $roles = array_merge($roles, $workgroup_roles);
       }
     }
-    return $roles;
+    return array_unique($roles);
   }
 
   /**
    * {@inheritdoc}
    */
   public function userInGroup($workgroup, $name) {
-    if ($response = $this->getWorkgroupApiResponse($workgroup)) {
-      $dom = new \DOMDocument();
-      $dom->loadXML((string) $response->getBody());
-      $xpath = new \DOMXPath($dom);
-
-      // Use xpath to find if the sunetid is one of the members.
-      return $xpath->query("//members/member[@id='$name']")->length > 0;
-    }
-    return FALSE;
+    return in_array($workgroup, $this->getAllUserWorkgroups($name));
   }
 
   /**
    * {@inheritdoc}
    */
   public function userInAnyGroup(array $workgroups, $name) {
-    foreach ($workgroups as $workgroup) {
-      if ($this->userInGroup($workgroup, $name)) {
-        return TRUE;
-      }
-    }
-    return FALSE;
+    return !empty(array_intersect($workgroups, $this->getAllUserWorkgroups($name)));
   }
 
   /**
    * {@inheritdoc}
    */
   public function userInAllGroups(array $workgroups, $name) {
-    foreach ($workgroups as $workgroup) {
-      if (!$this->userInGroup($workgroup, $name)) {
-        return FALSE;
-      }
-    }
-    return TRUE;
+    return count(array_intersect($workgroups, $this->getAllUserWorkgroups($name))) == count($workgroups);
   }
 
   /**
    * {@inheritDoc}
    */
   public function isWorkgroupValid($workgroup) {
-    if (!$this->connectionSuccessful()) {
-      return FALSE;
-    }
-
-    $response = $this->getWorkgroupApiResponse($workgroup);
-    $dom = new \DOMDocument();
-    $dom->loadXML((string) $response->getBody());
-    $xpath = new \DOMXPath($dom);
-    return $xpath->query('//visibility')->item(0)->nodeValue != 'PRIVATE';
+    return !empty($this->callApi($workgroup));
   }
 
   /**
@@ -206,31 +182,45 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
    * @return bool|\Psr\Http\Message\ResponseInterface
    *   API response or false if fails.
    */
-  protected function getWorkgroupApiResponse($workgroup) {
-    // We've already called the API for this group, use that result.
-    if (isset($this->workgroupResponses[$workgroup])) {
-      return $this->workgroupResponses[$workgroup];
-    }
+  protected function callApi($workgroup = NULL, $sunet = NULL) {
     $options = [
       'cert' => $this->getCert(),
       'ssl_key' => $this->getKey(),
       'verify' => TRUE,
       'timeout' => 5,
+      'query' => [
+        'type' => $workgroup ? 'workgroup' : 'user',
+        'id' => $workgroup ?: $sunet,
+      ],
     ];
 
-    $base_url = $this->configFactory->get('stanford_ssp.settings')
-      ->get('workgroup_api_url');
-    $base_url = trim($base_url, '/') ?: 'https://workgroupsvc.stanford.edu/v1/workgroups';
-
     try {
-      $result = $this->guzzle->request('GET', "$base_url/$workgroup", $options);
-      $this->workgroupResponses[$workgroup] = $result;
-      return $result;
+      $result = $this->guzzle->request('GET', self::WORKGROUP_API, $options);
+      return json_decode($result->getBody(), TRUE);
     }
     catch (GuzzleException $e) {
       $this->logger->error('Unable to connect to workgroup api. @message', ['@message' => $e->getMessage()]);
     }
     return FALSE;
+  }
+
+  /**
+   * Get a flat list of all the given user's workgroups.
+   *
+   * @param string $authname
+   *   Sunet id.
+   *
+   * @return array
+   *   Array of the user's workgroups.
+   */
+  protected function getAllUserWorkgroups($authname) {
+    $workgroup_names = [];
+    if ($user_data = $this->callApi(NULL, $authname)) {
+      foreach ($user_data['results'] as $user_member) {
+        $workgroup_names[] = $user_member['name'];
+      }
+    }
+    return $workgroup_names;
   }
 
 }

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -91,8 +91,12 @@ function stanford_ssp_update_8107() {
 /**
  * Remove workgroup api from configs since it is hardcoded.
  */
-function stanford_ssp_update_8108(){
-  \Drupal::configFactory()->getEditable('stanford_ssp.settings')
-    ->clear('workgroup_api_url')
-    ->save();
+function stanford_ssp_update_8108() {
+  $config = \Drupal::configFactory()->getEditable('stanford_ssp.settings');
+  /** @var \Drupal\stanford_ssp\Service\StanfordSSPWorkgroupApiInterface $api */
+  $api = \Drupal::service('stanford_ssp.workgroup_api');
+  if ($config->get('use_workgroup_api') && !$api->connectionSuccessful()) {
+    throw new \Exception('Workgroup API connection is enabled but is unable to connect to the API. Please check your certificate credentials or disable the workgroup API.');
+  }
+  $config->clear('workgroup_api_url')->save();
 }

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -87,3 +87,12 @@ function stanford_ssp_update_8107() {
     ->clear('whitelist_users')
     ->save();
 }
+
+/**
+ * Remove workgroup api from configs since it is hardcoded.
+ */
+function stanford_ssp_update_8108(){
+  \Drupal::configFactory()->getEditable('stanford_ssp.settings')
+    ->clear('workgroup_api_url')
+    ->save();
+}

--- a/tests/src/Kernel/Form/RoleSyncFormTest.php
+++ b/tests/src/Kernel/Form/RoleSyncFormTest.php
@@ -63,20 +63,8 @@ class RoleSyncFormTest extends KernelTestBase {
 
   public function guzzleCallback($method, $url, $options) {
     $response = $this->createMock(ResponseInterface::class);
+    $response->method('getBody')->willReturn(json_encode(['results' => []]));
 
-    $response->method('getBody')->willReturn('<?xml version="1.0" encoding="UTF-8"?>
-<workgroup>
-  <description>Test Workgroup</description>
-  <filter />
-  <visibility>STANFORD</visibility>
-  <reusable>FALSE</reusable>
-  <privgroup>TRUE</privgroup>
-  <members />
-  <administrators>
-    <member id="foo-bar" url="https://workgroupsvc.stanford.edu/v1/users/foo-bar" name="Foo, BAR" />
-  </administrators>
-</workgroup>
-');
     $response->method('getStatusCode')->willReturn(200);
     return $response;
   }
@@ -207,8 +195,8 @@ class RoleSyncFormTest extends KernelTestBase {
       ],
     ]);
     \Drupal::formBuilder()->submitForm($this->formId, $form_state);
-    $this->assertEqual(\Drupal::config('simplesamlphp_auth.settings')
-      ->get('role.population'), 'role1:eduPersonEnttitlement,=,foo:bar');
+    $this->assertEquals('role1:eduPersonEnttitlement,=,foo:bar', \Drupal::config('simplesamlphp_auth.settings')
+      ->get('role.population'));
   }
 
   /**

--- a/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
+++ b/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
@@ -83,7 +83,7 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
     $guzzle_response->method('getStatusCode')->willReturn(200);
 
     $body = [];
-    //var_dump($options['query']);
+    
     switch ($options['query']['id']) {
       case 'uit:sws':
         $body = [

--- a/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
+++ b/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
@@ -53,7 +53,6 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
       'stanford_ssp.settings' => [
         'workgroup_api_cert' => __FILE__,
         'workgroup_api_key' => __FILE__,
-        'workgroup_api_url' => '',
       ],
       'simplesamlphp_auth.settings' => [
         'role' => [

--- a/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
+++ b/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\stanford_ssp\Service\StanfordSSPWorkgroupApi;
 use Drupal\Tests\UnitTestCase;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ClientException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -67,35 +68,41 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
       ->will($this->returnCallback([$this, 'guzzleRequestCallback']));
 
     $logger = $this->createMock(LoggerChannelFactoryInterface::class);
-    $logger->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
+    $logger->method('get')
+      ->willReturn($this->createMock(LoggerChannelInterface::class));
     $this->service = new StanfordSSPWorkgroupApi($config_factory, $guzzle, $logger);
   }
 
-  public function guzzleRequestCallback($method, $url) {
+  public function guzzleRequestCallback($method, $url, $options) {
+    $request = $this->createMock(RequestInterface::class);
+    $guzzle_response = $this->createMock(ResponseInterface::class);
+
     if ($this->throwGuzzleException) {
-      $request = $this->createMock(RequestInterface::class);
-      $response = $this->createMock(ResponseInterface::class);
-      throw new ClientException('It broke', $request, $response);
+      throw new ClientException('It broke', $request, $guzzle_response);
     }
 
-    $guzzle_response = $this->createMock(ResponseInterface::class);
     $guzzle_response->method('getStatusCode')->willReturn(200);
 
-    $body = "<members></members>";
-    switch ($url) {
-      case 'https://workgroupsvc.stanford.edu/v1/workgroups/valid:workgroup':
-        $body = "<members><member id='{$this->authname}'/></members>";
+    $body = [];
+    //var_dump($options['query']);
+    switch ($options['query']['id']) {
+      case 'uit:sws':
+        $body = [
+          'results' => [],
+        ];
         break;
 
-      case 'https://workgroupsvc.stanford.edu/v1/workgroups/foo:bar':
-        $body = "<visibility>STANFORD</visibility>";
+      case $this->authname:
+        $body = [
+          'results' => [['name' => 'valid:workgroup']],
+        ];
         break;
 
-      case 'https://workgroupsvc.stanford.edu/v1/workgroups/bar:foo':
-        $body = "<workgroup><visibility>PRIVATE</visibility></workgroup>";
+      case 'bar:foo':
+        throw new ClientException('It broke', $request, $guzzle_response);
         break;
     }
-    $guzzle_response->method('getBody')->willReturn($body);
+    $guzzle_response->method('getBody')->willReturn(json_encode($body));
     return $guzzle_response;
   }
 
@@ -110,12 +117,11 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
   }
 
   public function testConnection() {
-    $this->assertEquals(200, $this->service->connectionSuccessful());
-    $this->assertEquals(200, $this->service->connectionSuccessful());
+    $this->assertTrue($this->service->connectionSuccessful());
   }
 
   public function testRoles() {
-    $this->assertArrayEquals(['valid_role'], $this->service->getRolesFromAuthname($this->authname));
+    $this->assertEquals(['valid_role'], $this->service->getRolesFromAuthname($this->authname));
   }
 
   public function testUserGroups() {
@@ -133,7 +139,7 @@ class StanfordSSPWorkgroupApiTest extends UnitTestCase {
    * Valid workgroups are public.
    */
   public function testValidWorkgroup() {
-    $this->assertTrue($this->service->isWorkgroupValid('foo:bar'));
+    $this->assertTrue($this->service->isWorkgroupValid('uit:sws'));
     $this->assertFalse($this->service->isWorkgroupValid('bar:foo'));
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Upgrade workgroup API to V2
- As far as i know, all of our workgroup api connections use the same cert so this should just be a normal upgrade.
   - If anyone (earth) might be using this module AND the workgroup api, it will verify the certs during the upgrade process and throw an error if it fails.

# Need Review By (Date)
- 4/28

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. re-install a site and log in using saml
3. verify you still get the expected role from the role mapping.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
