### PR TITLE
Fixed the destination path after saml login

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
     "composer/installers": "^1.2",
     "drupal/simplesamlphp_auth": "~3.1"
   },
+  "require-dev": {
+    "su-sws/drupal-patches": "^8.0"
+  },
   "extra": {
     "drush": {
       "services": {

--- a/src/EventSubscriber/StanfordSSPEventSubscriber.php
+++ b/src/EventSubscriber/StanfordSSPEventSubscriber.php
@@ -8,7 +8,7 @@ use Drupal\Core\Url;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -66,10 +66,10 @@ class StanfordSSPEventSubscriber implements EventSubscriberInterface {
   /**
    * Upon getting the kernel response, redirect 403 pages appropriately.
    *
-   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
    *   Response event object..
    */
-  public function responseHandler(FilterResponseEvent $event) {
+  public function responseHandler(ResponseEvent $event) {
 
     if (
       $event->getResponse()->getStatusCode() == Response::HTTP_FORBIDDEN &&
@@ -83,7 +83,9 @@ class StanfordSSPEventSubscriber implements EventSubscriberInterface {
       // Redirect anonymous users to login portal.
       $url = Url::fromRoute('user.login', [], ['query' => ['destination' => $destination]]);
       if ($this->samlConfig->get('activate') && $this->stanfordConfig->get('hide_local_login')) {
-        $url = Url::fromRoute('simplesamlphp_auth.saml_login', [], ['query' => ['destination' => $destination]]);
+        global $base_url;
+        $destination = "$base_url/$destination";;
+        $url = Url::fromRoute('simplesamlphp_auth.saml_login', [], ['query' => ['ReturnTo' => $destination]]);
       }
 
       $response = new RedirectResponse($url->toString());

--- a/tests/src/Kernel/EventSubscriber/StanfordSSPEventSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/StanfordSSPEventSubscriberTest.php
@@ -7,7 +7,7 @@ use Drupal\stanford_ssp\EventSubscriber\StanfordSSPEventSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -62,11 +62,11 @@ class StanfordSSPEventSubscriberTest extends KernelTestBase {
 
     $response = new Response('', Response::HTTP_FORBIDDEN);
     $kernel = $this->createMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
-    $event = new FilterResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+    $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
     $dispatcher->dispatch(KernelEvents::RESPONSE, $event);
 
     $target_url = $event->getResponse()->getTargetUrl();
-    $this->assertEquals('/saml_login?destination=', $target_url);
+    $this->assertStringContainsString('/saml_login?ReturnTo=http', $target_url);
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The contrib module actually expects the parameter `ReturnTo`, not `destination`. This fixes an issue when on an intranet site and attempt to go to the home page. Before, the destination failed to validate in the controller and so it fell back to the `/user` path. This passes the correct parameter with the expected string so that if a user lands on an intranet home page, they will log in and then go to the home page instead of their user page.
- https://git.drupalcode.org/project/simplesamlphp_auth/-/blob/8.x-3.x/src/Controller/SimplesamlphpAuthController.php#L150

# Need Review By (Date)
- 9/15

# Urgency
- medium

# Steps to Test
1. Checkout this branch
2. configure your site to be intranet `drush sset stanford_intranet 1; drush cr`
3. load your home page in a browser
4. log in and verify you land back on the home page after logging in.
5. Check this with some incognito windows and attempt other paths before logging in
6. verify if you try to go to a path, then you log in, you still end up on that path after logging in.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
