### PR TITLE
Expand the existing user lookup to prevent unwanted user duplication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,15 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.0.0",
-        "composer/installers": "^1.2",
-        "drupal/simplesamlphp_auth": "^3.1",
-        "ext-json": "*"
+        "php": ">=8.1",
+        "ext-json": "*",
+        "drupal/core": "^9.4 || ^10.0",
+        "drupal/simplesamlphp_auth": "^3.1"
     },
     "require-dev": {
         "su-sws/drupal-patches": "^8.0"
     },
+    "prefer-stable": true,
     "config": {
         "sort-packages": true
     },

--- a/config/install/stanford_ssp.settings.yml
+++ b/config/install/stanford_ssp.settings.yml
@@ -1,6 +1,8 @@
 saml_attribute: eduPersonEntitlement
 use_workgroup_api: false
 hide_local_login: true
+local_login_fieldset_label: 'Drupal Login'
+local_login_fieldset_open: false
 workgroup_api_cert: ''
 workgroup_api_key: ''
 restriction: all

--- a/config/schema/stanford_ssp.schema.yml
+++ b/config/schema/stanford_ssp.schema.yml
@@ -12,6 +12,12 @@ stanford_ssp.settings:
     hide_local_login:
       type: boolean
       label: 'Hide core local login form on user page'
+    local_login_fieldset_label:
+      type: string
+      label: 'Local login fieldset label'
+    local_login_fieldset_open:
+      type: boolean
+      label: Default open state for local login fieldset
     use_workgroup_api:
       type: boolean
       label: 'Use workgroup mapping instead of saml attributes'

--- a/src/Commands/StanfordSspCommands.php
+++ b/src/Commands/StanfordSspCommands.php
@@ -71,7 +71,7 @@ class StanfordSspCommands extends DrushCommands {
    * @command saml:entitlement-role
    * @aliases ssp-ser,saml-entitlement-role
    */
-  public function entitlementRole($entitlement, $role_id) {
+  public function entitlementRole(string $entitlement, string $role_id) {
     $role_id = Html::escape($role_id);
     $existing_roles = user_roles(TRUE);
     if (!isset($existing_roles[$role_id])) {
@@ -120,7 +120,7 @@ class StanfordSspCommands extends DrushCommands {
    * @command saml:add-user
    * @aliases ssp-au,saml-add-user
    */
-  public function addUser($sunetid, array $options = [
+  public function addUser(string $sunetid, array $options = [
     'name' => NULL,
     'email' => NULL,
     'roles' => NULL,

--- a/src/EventSubscriber/StanfordSSPEventSubscriber.php
+++ b/src/EventSubscriber/StanfordSSPEventSubscriber.php
@@ -84,7 +84,7 @@ class StanfordSSPEventSubscriber implements EventSubscriberInterface {
       $url = Url::fromRoute('user.login', [], ['query' => ['destination' => $destination]]);
       if ($this->samlConfig->get('activate') && $this->stanfordConfig->get('hide_local_login')) {
         global $base_url;
-        $destination = "$base_url/$destination";;
+        $destination = "$base_url/$destination";
         $url = Url::fromRoute('simplesamlphp_auth.saml_login', [], ['query' => ['ReturnTo' => $destination]]);
       }
 

--- a/src/Form/RoleSyncForm.php
+++ b/src/Form/RoleSyncForm.php
@@ -124,7 +124,7 @@ class RoleSyncForm extends SyncingSettingsForm {
       ],
     ];
 
-    foreach ($form_state->get('mappings', []) as $role_mapping) {
+    foreach ($form_state->get('mappings') as $role_mapping) {
       $form['user_info']['role_population'][$role_mapping] = $this->buildRoleRow($role_mapping);
     }
 
@@ -209,7 +209,7 @@ class RoleSyncForm extends SyncingSettingsForm {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  protected function buildRoleRow($role_mapping_string) {
+  protected function buildRoleRow(string $role_mapping_string): array {
     [$role_id, $comparison] = explode(':', $role_mapping_string, 2);
 
     $exploded_comparison = explode(',', $comparison, 3);
@@ -287,7 +287,7 @@ class RoleSyncForm extends SyncingSettingsForm {
    *   Current form state.
    */
   public function removeMappingCallback(array $form, FormStateInterface $form_state) {
-    $mappings = $form_state->get('mappings', []);
+    $mappings = $form_state->get('mappings');
     unset($mappings[$form_state->getTriggeringElement()['#mapping']]);
     $form_state->set('mappings', $mappings);
     $form_state->setRebuild();

--- a/src/Service/StanfordSSPAuthManager.php
+++ b/src/Service/StanfordSSPAuthManager.php
@@ -55,6 +55,7 @@ class StanfordSSPAuthManager extends SimplesamlphpAuthManager {
         return $this->getAuthname() . '@stanford.edu';
       }
     }
+    return FALSE;
   }
 
 }

--- a/src/Service/StanfordSSPWorkgroupApi.php
+++ b/src/Service/StanfordSSPWorkgroupApi.php
@@ -150,7 +150,7 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
   /**
    * {@inheritdoc}
    */
-  public function userInGroup(array $workgroup, string $name): bool {
+  public function userInGroup(string $workgroup, string $name): bool {
     return in_array($workgroup, $this->getAllUserWorkgroups($name));
   }
 

--- a/src/Service/StanfordSSPWorkgroupApi.php
+++ b/src/Service/StanfordSSPWorkgroupApi.php
@@ -205,7 +205,7 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
     catch (GuzzleException $e) {
       $this->logger->error('Unable to connect to workgroup api. @message', ['@message' => $e->getMessage()]);
     }
-    return FALSE;
+    return NULL;
   }
 
   /**

--- a/src/Service/StanfordSSPWorkgroupApi.php
+++ b/src/Service/StanfordSSPWorkgroupApi.php
@@ -77,50 +77,51 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
     }
   }
 
+
   /**
    * {@inheritdoc}
    */
-  public function setCert($cert_path) {
+  public function setCert(string $cert_path): void {
     $this->cert = $cert_path;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setKey($key_path) {
+  public function setKey(string $key_path): void {
     $this->key = $key_path;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getCert() {
+  public function getCert(): ?string {
     return $this->cert;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getKey() {
+  public function getKey(): ?string {
     return $this->key;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function connectionSuccessful() {
+  public function connectionSuccessful(): bool {
     return !empty($this->callApi('uit:sws'));
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getRolesFromAuthname($authname) {
+  public function getRolesFromAuthname($authname): array {
     $roles = [];
     if (!$this->cert || !$this->key) {
       return $roles;
     }
-    $config = $this->configFactory->get('simplesamlphp_auth.settings');;
+    $config = $this->configFactory->get('simplesamlphp_auth.settings');
     $role_population = array_filter(explode('|', $config->get('role.population') ?: ''));
     $workgroup_mappings = [];
 
@@ -149,28 +150,28 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
   /**
    * {@inheritdoc}
    */
-  public function userInGroup($workgroup, $name) {
+  public function userInGroup(array $workgroup, string $name): bool {
     return in_array($workgroup, $this->getAllUserWorkgroups($name));
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userInAnyGroup(array $workgroups, $name) {
+  public function userInAnyGroup(array $workgroups, string $name): bool {
     return !empty(array_intersect($workgroups, $this->getAllUserWorkgroups($name)));
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userInAllGroups(array $workgroups, $name) {
+  public function userInAllGroups(array $workgroups, string $name): bool {
     return count(array_intersect($workgroups, $this->getAllUserWorkgroups($name))) == count($workgroups);
   }
 
   /**
    * {@inheritDoc}
    */
-  public function isWorkgroupValid($workgroup) {
+  public function isWorkgroupValid(string $workgroup): bool {
     return !empty($this->callApi($workgroup));
   }
 
@@ -182,10 +183,10 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
    * @param string|null $sunet
    *   User sunetid.
    *
-   * @return bool|\Psr\Http\Message\ResponseInterface
+   * @return bool|array
    *   API response or false if fails.
    */
-  protected function callApi($workgroup = NULL, $sunet = NULL) {
+  protected function callApi(string $workgroup = NULL, string $sunet = NULL): ?array {
     $options = [
       'cert' => $this->getCert(),
       'ssl_key' => $this->getKey(),
@@ -213,10 +214,10 @@ class StanfordSSPWorkgroupApi implements StanfordSSPWorkgroupApiInterface {
    * @param string $authname
    *   Sunet id.
    *
-   * @return array
+   * @return string[]
    *   Array of the user's workgroups.
    */
-  protected function getAllUserWorkgroups($authname) {
+  protected function getAllUserWorkgroups(string $authname): array {
     $workgroup_names = [];
     if ($user_data = $this->callApi(NULL, $authname)) {
       foreach ($user_data['results'] as $user_member) {

--- a/src/Service/StanfordSSPWorkgroupApiInterface.php
+++ b/src/Service/StanfordSSPWorkgroupApiInterface.php
@@ -15,7 +15,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @param string $cert_path
    *   Path to file.
    */
-  public function setCert($cert_path);
+  public function setCert(string $cert_path): void;
 
   /**
    * Get the current cert path.
@@ -23,7 +23,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @return string|null
    *   Absolute cert path.
    */
-  public function getCert();
+  public function getCert(): ?string;
 
   /**
    * Set the key file path.
@@ -31,7 +31,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @param string $key_path
    *   Path to file.
    */
-  public function setKey($key_path);
+  public function setKey(string $key_path): void;
 
   /**
    * Get the current cert key path.
@@ -39,7 +39,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @return string|null
    *   Absolute key path.
    */
-  public function getKey();
+  public function getKey(): ?string;
 
   /**
    * Check if a given cert and key will connect to the workgroup api.
@@ -47,7 +47,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @return bool
    *   If the connection was successful.
    */
-  public function connectionSuccessful();
+  public function connectionSuccessful(): bool;
 
   /**
    * Get an array of roles for the user based on the saml role mapping.
@@ -55,10 +55,10 @@ interface StanfordSSPWorkgroupApiInterface {
    * @param string $authname
    *   User sunetid.
    *
-   * @return array
+   * @return string[]
    *   Array of role ids.
    */
-  public function getRolesFromAuthname($authname);
+  public function getRolesFromAuthname($authname): array;
 
   /**
    * Check if the given name is part of the workgroup provided.
@@ -71,7 +71,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @return bool
    *   If the user is part of the group.
    */
-  public function userInGroup($workgroup, $name);
+  public function userInGroup(string $workgroup, string $name): bool;
 
   /**
    * Check if the given name is part of any workgroup provided.
@@ -84,7 +84,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @return bool
    *   If the user is part of any group.
    */
-  public function userInAnyGroup(array $workgroups, $name);
+  public function userInAnyGroup(array $workgroups, string $name): bool;
 
   /**
    * Check if the given name is part of all workgroups provided.
@@ -97,7 +97,7 @@ interface StanfordSSPWorkgroupApiInterface {
    * @return bool
    *   If the user is part of all groups.
    */
-  public function userInAllGroups(array $workgroups, $name);
+  public function userInAllGroups(array $workgroups, string $name): bool;
 
   /**
    * Check if the workgroup is valid and is public.
@@ -105,9 +105,9 @@ interface StanfordSSPWorkgroupApiInterface {
    * @param string $workgroup
    *   Workgroup name to test.
    *
-   * @return bool|null
-   *   True if the given workgroup is valid, null if unknown.
+   * @return bool
+   *   True if the given workgroup is valid, false if unknown.
    */
-  public function isWorkgroupValid($workgroup);
+  public function isWorkgroupValid(string $workgroup): bool;
 
 }

--- a/stanford_ssp.info.yml
+++ b/stanford_ssp.info.yml
@@ -1,6 +1,5 @@
 name: Stanford SimpleSAML PHP
 description: Configures SimpleSAML PHP auth to work in Stanford web environment
-core: 8.x
 core_version_requirement: ^9 || ^10
 type: module
 version: 8.x-2.6-dev

--- a/stanford_ssp.info.yml
+++ b/stanford_ssp.info.yml
@@ -1,7 +1,7 @@
 name: Stanford SimpleSAML PHP
 description: Configures SimpleSAML PHP auth to work in Stanford web environment
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 type: module
 version: 8.x-2.6-dev
 package: Stanford

--- a/stanford_ssp.install
+++ b/stanford_ssp.install
@@ -69,7 +69,7 @@ function stanford_ssp_update_8001() {
 
   if ($set_form) {
     EntityFormDisplay::load('user.user.default')
-      ->set('su_display_name')->save();
+      ->setComponent('su_display_name')->save();
 
     EntityViewDisplay::load('user.user.default')
       ->setComponent('su_display_name')->save();

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -126,20 +126,6 @@ function stanford_ssp_simplesamlphp_auth_allow_login($attributes) {
   return FALSE;
 }
 
-function mikes(){
-//  /** @var \Drupal\user\UserStorageInterface $user_storage */
-//  $user_storage = \Drupal::service('entity_type.manager')
-//    ->getStorage('user');
-//  dpm($user_storage->loadByProperties(['mail' => ['foobar@gmail.com', 'mike.decker@stanford.edu']]));
-  $a = [
-    'foobar@stnaford.edu',
-  ];
-  $b = [
-    'mike.decker@stanford.edu',
-  ];
-  dpm([...$a, ...$b]);
-}
-
 /**
  * Default attribute values.
  *

--- a/stanford_ssp.module
+++ b/stanford_ssp.module
@@ -68,8 +68,8 @@ function stanford_ssp_form_user_login_form_alter(&$form, FormStateInterface $for
     $form['simplesamlphp_auth_login_link']['#weight'] = -99;
     $form['manual'] = [
       '#type' => 'details',
-      '#title' => t('Drupal Login'),
-      '#open' => FALSE,
+      '#title' => $config->get('local_login_fieldset_label') ?: t('Drupal Login'),
+      '#open' => $config->get('local_login_fieldset_open') ?: FALSE,
     ];
     $form['manual']['name'] = $form['name'];
     $form['manual']['pass'] = $form['pass'];
@@ -96,7 +96,7 @@ function stanford_ssp_simplesamlphp_auth_allow_login($attributes) {
   $auth_manager = \Drupal::service('simplesamlphp_auth.manager');
   $authname = $auth_manager->getAuthname();
 
-  // Check if the user name is allowed.
+  // Check if the username is allowed.
   if (in_array($authname, $config->get('allowed.users'))) {
     return TRUE;
   }
@@ -126,17 +126,63 @@ function stanford_ssp_simplesamlphp_auth_allow_login($attributes) {
   return FALSE;
 }
 
+function mikes(){
+//  /** @var \Drupal\user\UserStorageInterface $user_storage */
+//  $user_storage = \Drupal::service('entity_type.manager')
+//    ->getStorage('user');
+//  dpm($user_storage->loadByProperties(['mail' => ['foobar@gmail.com', 'mike.decker@stanford.edu']]));
+  $a = [
+    'foobar@stnaford.edu',
+  ];
+  $b = [
+    'mike.decker@stanford.edu',
+  ];
+  dpm([...$a, ...$b]);
+}
+
+/**
+ * Default attribute values.
+ *
+ * @return array[]
+ *   Default keyed values.
+ */
+function _stanford_ssp_default_attributes(){
+  return [
+    'displayName' => [],
+    'eduPersonPrincipalName' => [],
+    'mail' => [],
+  ];
+}
+
 /**
  * Implements hook_simplesamlphp_auth_existing_user().
  */
 function stanford_ssp_simplesamlphp_auth_existing_user($attributes) {
-  if (!empty($attributes['eduPersonPrincipalName'])) {
-    $saml_mail = $attributes['eduPersonPrincipalName'];
-    $saml_mail = is_array($saml_mail) ? reset($saml_mail) : $saml_mail;
-    $existing_users = \Drupal::service('entity_type.manager')
-      ->getStorage('user')
-      ->loadByProperties(['mail' => $saml_mail]);
-    return is_array($existing_users) && !empty($existing_users) ? reset($existing_users) : FALSE;
+  /** @var \Drupal\user\UserStorageInterface $user_storage */
+  $user_storage = \Drupal::service('entity_type.manager')
+    ->getStorage('user');
+  $attributes = $attributes + _stanford_ssp_default_attributes();
+
+  $email_values = array_filter([
+    ...$attributes['eduPersonPrincipalName'],
+    ...$attributes['mail'],
+  ]);
+  // Search for an existing email that matches the `eduPersonPrincipalName`
+  // email value.
+  if (count($email_values)) {
+    $existing_users = $user_storage->loadByProperties(['mail' => $email_values]);
+    if ($existing_users) {
+      return reset($existing_users);
+    }
+  }
+
+  // Look at the authmap table. See if a user was previously created using the
+  // display name. This is rare, but it happens on occasion. If this succeeds,
+  // the `authname` will be converted to the sunetID properly for future logins.
+  /** @var \Drupal\externalauth\AuthmapInterface $authmap */
+  $authmap = \Drupal::service('externalauth.authmap');
+  if ($uid = $authmap->getUid(reset($attributes['displayName']), 'simplesamlphp_auth')) {
+    return $user_storage->load($uid);
   }
   return FALSE;
 }
@@ -158,7 +204,7 @@ function stanford_ssp_simplesamlphp_auth_user_attributes(UserInterface $account,
     // Only set the display name if configured to sync the username every time
     // or if the display name is empty.
     if ($always_sync_name || !$account->get('su_display_name')->count()) {
-      $account->set('su_display_name', $attributes['displayName']);
+      $account->set('su_display_name', reset($attributes['displayName']));
       return $account;
     }
   }

--- a/tests/src/Kernel/Form/RoleSyncFormTest.php
+++ b/tests/src/Kernel/Form/RoleSyncFormTest.php
@@ -205,7 +205,7 @@ class RoleSyncFormTest extends KernelTestBase {
    * @param bool $successful_connection
    *   If the connection should be successful.
    */
-  protected function setWorkgroupApiMock($successful_connection = FALSE) {
+  protected function setWorkgroupApiMock(bool $successful_connection = FALSE) {
     $workgroup_api = $this->createMock(StanfordSSPWorkgroupApiInterface::class);
     $workgroup_api->method('connectionSuccessful')
       ->willReturn($successful_connection);

--- a/tests/src/Unit/Service/StanfordSSPDrupalAuthTest.php
+++ b/tests/src/Unit/Service/StanfordSSPDrupalAuthTest.php
@@ -61,7 +61,7 @@ class StanfordSSPDrupalAuthTest extends UnitTestCase {
    * @return \Drupal\stanford_ssp\Service\StanfordSSPDrupalAuth
    *   Constructed service.
    */
-  protected function getService($return_account = TRUE, $role_setting = 1, $return_attributes = TRUE) {
+  protected function getService(bool $return_account = TRUE, int $role_setting = 1, bool $return_attributes = TRUE): StanfordSSPDrupalAuth {
     $this->removeRole = $this->randomMachineName();
     $this->addRole = $this->randomMachineName();
 

--- a/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
+++ b/tests/src/Unit/Service/StanfordSSPWorkgroupApiTest.php
@@ -7,7 +7,6 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\stanford_ssp\Service\StanfordSSPWorkgroupApi;
 use Drupal\Tests\UnitTestCase;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ClientException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;


### PR DESCRIPTION
- Expand the existing user lookup to prevent unwanted user duplication

# READY FOR REVIEW

# Summary
- More existing user lookup to prevent `simplesamlphp_auth_[sunet]` error.
- Not sure how the error even comes about, but this fixes it.

# Urgency
- High

# Review Tasks

## Setup tasks and/or behavior to test

0. USE THE MAIN BRANCH FIRST
1. log into a site using saml
2. alter the database `drush sqlq 'UPDATE authmap a INNER JOIN users_field_data u ON a.uid = u.uid SET a.authname = u.name'`
3. log out of the site `/user/logout`
4. log back into the site.
5. view the error.
6. Delete the bad account `drush ucan 'simplesamlphp_auth_[sunetid]' --delete-content -y`
7. Checkout this branch
8. repeat the process but on this branch
9. verify you don't see the error.